### PR TITLE
Update survey example to use declarativewidgets@0.4.5

### DIFF
--- a/surveys/2015-notebook-ux/analysis/prep/widgets/survey-explorer/survey-explorer.html
+++ b/surveys/2015-notebook-ux/analysis/prep/widgets/survey-explorer/survey-explorer.html
@@ -10,7 +10,24 @@ Example:
 @element survey-explorer
 -->
 <dom-module id="survey-explorer">
-    <template>
+    <template is="dom-bind">
+        <style>
+        .select-bar {
+          background-color: #ddd; padding: 10px;
+        }
+
+        .item-list {
+          max-height: 300px; min-height: 300px; overflow: auto; background-color: #eee; border: 1px solid #ccc;
+        }
+
+        .item-list hr {
+          padding: 0; margin: 0;
+        }
+
+        .item {
+          padding: 15px; background-color: white;
+        }
+        </style>
         <paper-dropdown-menu label="Choose a series" noink no-animations selected-item-label="{{selectedLabel}}">
             <paper-menu class="dropdown-content" selected="0">
                 <template is="dom-repeat" items="[[labelSlice(labels,series)]]">
@@ -30,26 +47,26 @@ Example:
         </paper-dropdown-menu>
         <paper-toggle-button checked="{{percentages}}">Use percentages</paper-toggle-button>
         <urth-core-function ref="exploreDataFrame" arg-series="{{seriesByLabel(selectedLabel)}}" arg-group_by="{{group_by}}" arg-percentages="{{percentages}}" result="{{df}}" auto></urth-core-function>
-        <urth-viz-bar datarows="{{df.data}}" columns="{{df.columns}}" xlabel="{{xlabel}}" ylabel="{{ylabel}}"  margin='{"bottom":100, "right":50}' rotatelabels="25" selection="{{sel}}">
+        <urth-viz-bar datarows="{{df.data}}" columns="{{df.columns}}" xlabel="{{xlabel}}" ylabel="{{ylabel}}"  margin='{"bottom":100, "right":50}' rotatelabels="25" selection-info="{{sel}}">
             <template is="dom-if" if="{{percentages}}" restamp="true">
                 <urth-viz-col index="1" type="numeric" format="%"></urth-viz-col>
             </template>
         </urth-viz-bar>
         <urth-core-function ref="getSample" arg-keyword="[[sel.0.x]]" arg-groupby="[[group_by]]" arg-sample_size="10" result="{{sampleData}}" arg-groupby_key="[[sel.0.key]]" arg-series="{{seriesByLabel(selectedLabel)}}" arg-sample_source="{{sampleSource}}" auto></urth-core-function>
-        <div style="background-color: #ddd; padding: 10px;">
+        <div class="select-bar">
             <em>Select a bar above.</em>
             <template is="dom-if" if="{{sel.length}}">
                 <span>Showing a random sample of up to 10 responses for "[[sel.0.x]]" in the "[[sel.0.key]]" group.</span>
             </template>
         </div>
-        <div style="max-height:300px; min-height:300px; overflow:auto; background-color: #eee; border: 1px solid #ccc;">
+        <div class="item-list">
            <template is="dom-repeat" items="[[sampleData.data]]">
                <template is="dom-repeat" items="[[item]]">
                    <template is="dom-if" if="[[item]]">
-                       <div style="padding: 15px; background-color: white;">[[item]]</div>
+                       <div class="item">[[item]]</div>
                    </template>
                </template>
-               <hr style="padding: 0; margin: 0;"/>
+               <hr/>
            </template>
         </div>
         <content></content>

--- a/surveys/2015-notebook-ux/analysis/report_dashboard_decl_widgets.ipynb
+++ b/surveys/2015-notebook-ux/analysis/report_dashboard_decl_widgets.ipynb
@@ -534,8 +534,8 @@
    "source": [
     "%%html\n",
     "<template is=\"dom-bind\">\n",
-    "    <urth-core-dataframe id=\"oftenData\" ref=\"how_often_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c1\" xlabel=\"Notebook Usage\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-core-dataframe ref=\"how_often_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
+    "    <urth-viz-bar xlabel=\"Notebook Usage\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },
@@ -614,7 +614,7 @@
     "%%html\n",
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"how_long_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c3\" xlabel=\"Notebook Experience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-viz-bar xlabel=\"Notebook Experience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },
@@ -677,7 +677,7 @@
     "%%html\n",
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"long_x_often_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c3b\" xlabel=\"Notebook Experience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-viz-bar xlabel=\"Notebook Experience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },
@@ -816,7 +816,7 @@
     "%%html\n",
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"yearcounts_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c14\" xlabel=\"Years in Job Role\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-viz-bar xlabel=\"Years in Job Role\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },
@@ -896,7 +896,7 @@
     "%%html\n",
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"howrun_counts_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c5\" xlabel=\"Notebook Environment\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-viz-bar xlabel=\"Notebook Environment\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },
@@ -1018,7 +1018,7 @@
     "%%html\n",
     "<template is=\"dom-bind\">\n",
     "    <urth-core-dataframe ref=\"audiencesize_dataframe\" value=\"{{df}}\" auto></urth-core-dataframe>\n",
-    "    <urth-viz-bar id=\"c16\" xlabel=\"Typical Notebook Audience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
+    "    <urth-viz-bar xlabel=\"Typical Notebook Audience\" ylabel=\"Respondants\" datarows=\"{{df.data}}\" columns=\"{{df.columns}}\"></urth-viz-bar>\n",
     "</template>"
    ]
   },

--- a/surveys/2015-notebook-ux/analysis/report_dashboard_decl_widgets.ipynb
+++ b/surveys/2015-notebook-ux/analysis/report_dashboard_decl_widgets.ipynb
@@ -182,7 +182,7 @@
     "ipywidgets==4.1.1\n",
     "jupyter_cms==0.4.0\n",
     "pandas==0.18.0\n",
-    "jupyter-declarativewidgets==0.4.3dev0\n",
+    "jupyter-declarativewidgets==0.4.5\n",
     "jupyter-dashboards==0.4.2 (optional)\n",
     "```"
    ]


### PR DESCRIPTION
uses `selection-info` attribute required by 0.4.5
also a bit of cleanup: removed unnecessary ids, moved CSS to style