### PR TITLE
Fix broken brand guide PDF link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ README page, rather than individual files.
 
 # Jupyter Brand Guide
 
-The Jupyter Brand Guide can be found [here](https://github.com/jupyter/design/raw/master/brandguide/jupyter_brand_guide.pdf).
+The Jupyter Brand Guide can be found [here](https://github.com/jupyter/design/raw/master/brandguide/brand_guide.pdf).
 
 # UX Survey
 


### PR DESCRIPTION
Fixes a broken link, apparently the file had been renamed from `jupyter_brand_guide.pdf` to `brand_guide.pdf`.