### PR TITLE
adding logo generator template

### DIFF
--- a/logos/Logo Generator/logo-generator.ai
+++ b/logos/Logo Generator/logo-generator.ai
@@ -1,0 +1,513 @@
+%PDF-1.5%âãÏÓ
+1 0 obj<</Metadata 2 0 R/OCProperties<</D<</ON[7 0 R 29 0 R]/Order 30 0 R/RBGroups[]>>/OCGs[7 0 R 29 0 R]>>/Pages 3 0 R/Type/Catalog>>endobj2 0 obj<</Length 16106/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c145 79.163499, 2018/08/13-16:40:22        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:illustrator="http://ns.adobe.com/illustrator/1.0/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <xmp:CreatorTool>Adobe Illustrator CC 23.0 (Windows)</xmp:CreatorTool>
+         <xmp:CreateDate>2019-10-29T14:43:22-07:00</xmp:CreateDate>
+         <xmp:MetadataDate>2019-10-29T14:49:06-07:00</xmp:MetadataDate>
+         <xmp:ModifyDate>2019-10-29T14:49:06-07:00</xmp:ModifyDate>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>148</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAlAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9TBj+P6ziruZ6+xxVvkR&#xA;t3/sxVrka9QenT54q3zP+fbFXBj3piq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq&#xA;7FXYq7FXYq7FXYq7FXYq0xpiruQ39tsVcXAxVwYYq3UVpirXIUr2OKu5LiruS4q7kMVcSewr74q4&#xA;N47V3+/FXchiruVTt9OKu5DFW+QrTvirTEgdK4q7kK4q7mK4q6p22xV1RQHxxV3KvQb+GKtg1xV2&#xA;KuxV2KuxV2KuxV2KuxV2KuxVohaU6DFXcR2PTFWiq+NB/ZirfEfca4q4qCcVdxFAPDFXcBTFXFR9&#xA;+Ku4D+OKt7DbFWuI/V+GKu4ClP8APbFXKCK1xVriK1P+ffFXcd+v+3irfbfFXcQd8VdwGKt9t8Va&#xA;4Dbc7dMVcFAOKtgUGKuxV2KuxV2KuqPHFXYq7FXYq7FXYq0wJA8cVao337nFWirfT/ZirqEbeJNc&#xA;VbIauKuo3EePfFWqNTv3xVshu30Yq6j0/wA+mKtlaj32xVqjf1xVo8thXft9+KtgNtWuKu4mv0/w&#xA;xVqj/wCfjirY3ah361xVxB3p/mMVaYn8Nvniq7Y9e2KtUb3998Vao+Kt0bf6e+Kuo3+fzxVri30f&#xA;24q2OVDv8sVaIbsD9JxVsLSpOKrhWgr1xV2KuxV2KuxVaxNBTx/z64q4Ma067VxVrmaE/d91cVbL&#xA;UGKuDGtOvhirg/tirizVp7/wxVsNU9MVaD70pirufen+ZxV3P8K4q7ma0piruft8/vpirixBO3eg&#xA;xVxc9h4fjiq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWiQKbVxV1FNMVd8I2xV3wHw&#xA;9sVaJXpirYC9Birqr7VxVrkle3zxVv4fbbFXfD7Yq4caV2pirvh9q4q18J+jFWzx798VceA8MVb5&#xA;Dbfr0xV3IUrXbFWgwP0Yq3UeOKtchT8aYq7kNt+uKtlgK79MVaLAfTirdR49cVa5Dffp1xVxYDvi&#xA;reKuxV2KuxV2KuxVoqDQdsVaCb1ririvviruHvirZWpr8vwxVoJQ1riruG9a4q3xPj4/jirXDwPT&#xA;pirglB1xVvjtSv04q4LT9WKuC7U+X4Yq0VJp7d8Vdw9+ta/TirZWv3UxV3HY77nFWile+Kt8enti&#xA;q3genbx+imKruO9f8+lMVaKV7/5nFWytTirXDeuKtla9/fFWuHv/AJjFV2KuxV2KuxV2KuxVa1SB&#xA;Ud/niriWFfDttirqt7+2KuHKorXvirXxDx74q2QS33b4q0A1APb+mKt9RQCm9MVcw36V7Yq1Q9SP&#xA;Y/Riq4bgbUxVaee+KrlJ71xVvFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWqjtv&#xA;irQevUbbYq2rVxVoOMVdz9tsVb5DFWi9OopSmKt8x4Gvhiri4FPA74q7mMVdy2Bp1xVoP4/574q3&#xA;zGKtBq09+v3Yq3zGKuDVNKYq1zHfFW+Q271xVrmPo/sxV3Pfp88VdzFDTqMVXA1GKuxV2KuxV2Ku&#xA;xV2KuxV2KuxV2KuI/DFWuIxVsKBirXEYq7iMVdxXFXcRiruIxV3Ebe2Ku4jFXcRSnbFXcRiruK4q&#xA;7iMVdxGKt8RirXFcVcVBp7Yq7ivhiruIxV3EYq2BQYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FX&#xA;Yq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXY&#xA;q7FUv1rX9H0W3S41S6W1hkcRozAklj2AUE4qjYZop4Y5oXEkMqh45FNVZWFQQfAjFV+KuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KpB5wtvNc9nb/wCHb2Gx&#xA;mjmD3Us4BHpAGvVXFK7nb6cSaUC2Oax5613UbqSz8q2ryxRni16sZckjutRxUf634Zz+o7Ty5JGO&#xA;AWO+npNN2VhxREtRKif4br9vySv6n+bC/v8Alddenqxn/hOX8MxfD1/P1fMfc5fi9ncvT8j99Lbz&#xA;UP0z9W0bz3aTW4WTlb6gg9BgxHE8wRwKmu7KNsy9N2pkhIQzir61Xz/Y4Wq7JxziZ6eV1/Dd/L9R&#xA;epWVpb2VnBaWy8Le3jWKFetEQBVFT7DN+86rYq7FXYq7FXYqo/XLP6x9W9eP6zSvoc1508eNa4qr&#xA;Yq7FXYqwvyZ5/uvMXmvzLoz2iW0GhTm3jkVi7yFZZIyzVAAr6dafjirNMVUoru1ld44pkkkj+2is&#xA;GK/MA7Yqq4qtM0QlWIuolYErGSORA6kDriryjzH+W2v6V5e1TVI/POuySWFpPdJG1zIFZoYmcKaP&#xA;0PHFUu/L/wAk+Y/M/lGw1y487a5bzXnq8oY7qUqvpTPEKEvXcJXFUT+aFm9l5o/KyzknkupLa+SF&#xA;7qY8pJTHNZqZHJrVmpU++KvYcVS3zLp+pahoN7ZaZeHT7+eIpb3i1rGx77bjwqNx1xVT8qaZq2me&#xA;XrKw1a+OpajAhW4vWqS5LEjdviPFSFqdzSuKptirsVdirsVdirsVdiqG1Gxjv7R7SZmEEtBMFNCy&#xA;VqUr2DdD7ZXlxCceE8i24cpxy4hzHL9arbW1vbQpBbxrDCgokaAKoHsBkoQERQFBhOcpG5GyqZJi&#xA;o3llaXtu1vdwpPA+zRuAR/t5DJjjMVIWGePLKEuKJotWNotnaRWqOzpCOEZc1bgPsgnvQbYMWPgi&#xA;I9ycuTjkZHq6/wD94bn/AIxP/wAROWNby7/nGv8A5QW+/wC2pL/1DwYqh/8AnHT/AHh8x/8AMeP+&#xA;InFXecP/AFobyp/zAD9d3iqD/OmPVJPzG8qQ6TP9U1K6ja1guxsY/XkMRcHr8KyEim/hiqYa9+QH&#xA;l9dCmm0q5ul8w26meK/klLNNMo5UcdByPQrQj3xVAadLe/mP+SF3FeE3Gs6TI4imY8nkltUEiMfF&#xA;nik9Mnud8VZN+XPnuCb8p11m7fnLodvJBeAnctap8Ar4vHw+k4qkf5OeTIdX8l6xqWuKzy+a5nM7&#xA;g8XMKOdwaVHKUufuxViv5e/lj5W1zzl5u0q/jma00a6eGyCSFWCCeWMcjT4vhjGKss/NvXPS1fQP&#xA;IcWpfobSrqJZdVv2cIRaqWRE9Q06+i23c0+RVY15z0b8rdF0VdY8j65FaeYtNaOSD0LsyvP8YVgV&#xA;Zm3oa/CKdiKYqyT81dabXPySsdXZQsl6bSWVR0Eh+2BXsGrTFU0/LT8vAslh541m9nu/MV7D6/Es&#xA;BBHFcR0SMLxr8MbU60HQDbFWX+ff+UF8x/8AbLvf+od8VSH8jv8AyVuif9HX/UXNirGfz2W+bzR5&#xA;BXT3WO/a+lFpI45IsxmtfTZh3AalcVXedvyjt7Dy9e+Y7LV9QfzNpsL3j6lLOS0vpD1JBQU4DiDx&#xA;Cnb3xVPbXzBc+YfyPvdXuiDdXGjXyzsBTlJDHLEzU/yjHXFUp8l/+s53H/bL1b/idziqV/lx+Xqe&#xA;cvI+n3nmXULmXT0R7fS9Nt5PRhijhkZDI4APOQup3Pb8FU0/Ku51XQvPPmDyDdXkl9ZafGt3p8kx&#xA;5OkZ9Mha+6zrUdKjamKoHQtPuvzW1vVdU1e8uI/Kmn3DWmnabbyGNJSo3aQjrVSrHv8AFQGgxVJf&#xA;zm8mN5R8sRJo17cf4fvrhILjS7iQzJHMitJE8JbddkYMPlir6AxV2KuxVSuru3tYvVuHEcXJVLn7&#xA;ILHiKnsKmlchOYiLPJnDHKZqO5VcmwdiriQASTQDck4qpW11BdQLPA4khevBx0YAkVHiNtjkYTEh&#xA;Y5M5wMDR5rb/AP3huf8AjE//ABE5Jg8u/wCca/8AlBb7/tqS/wDUPBirHvyt82aP5G1rzN5f8zzH&#xA;T5frRlhmdHKvw5Aj4Q32l4svj92KrP8AFMHmf89fLuq2UMi6YI2trG4kRk9dIknLSKGANObsv0Yq&#xA;jvzs1J9M/MXyhqKQPdG0pMbeMVdwk4JVQO5HTFWT+YPzw8j2/lya80y/F3qEsRFnZojrJ6rCi86g&#xA;cAp3Nforiqt+Rvlm90HyLEL2Mw3WozPetEwo6I6qkYbwqsYanauKvJ/Num6xoPmXXPIGmRn6n5pu&#xA;7SaxWtEWN5CwAA/ZD/AT4Jir6O0fS7XStKs9MtRS3soUgi8eMahamnc0qcVeLeTfM+ieUfzP87xe&#xA;Ybn6gL26ea3kdXKkGaSUD4Qx+JJQRiqN/OCxg03zp5f87Xenrqnl9YxaanA8SyoFJfi7o4KklZqp&#xA;X9pR02xVNm8z/wDOPa2gujb6PwK8vTGnoZN+3piHlX6MVd+ecFhB+Vgi0+KOGyWe2+rxQqEjCEkj&#xA;iqgADfFWd+Uf+UU0X/mAtv8AkyuKqHn3/lBfMf8A2y73/qHfFUh/I7/yVuif9HX/AFFzYqkX5x/8&#xA;p1+W/wD21D/1EWmKs78+/wDKC+Y/+2Xe/wDUO+KsE8l/+s53H/bL1b/idzirvJf/AKzncf8AbL1b&#xA;/idziqe/kd/5K3RP+jr/AKi5sVSLy5/60Z5p/wC2XH/xCyxVLPy31/T/AMvNX1nyb5lf9Hwtdtd6&#xA;ZeygiGVHASvOm1UjUgnbqDQ9VUu/Prz1o2u6Faadosn1+2t7xJru/iBMCSelKscQk6FmUu23YYq9&#xA;8xV2KuxVQvks5LOeO94/VHRln9QhV4EUNSaUyM4CQMTyLKEzCQkOYedTN5x8vp6uh3X6X0M19EqB&#xA;cBFH7LcasKf5Jp8s57LDVaU+g8eP51+l6XFPSasfvBwZPlf6P0ob/la/mM/uhZW3r9KcJev+rzrl&#xA;H8uZuXDG/j+tyP5Awc+KVfD9SYadp/nXzRKra3K9lo9avbqPRMo/lC/aofFvozIxYtTqj+9Jjj7u&#xA;V/jzcXNm0ukH7oCWTv51+j5PQ4oo4YkiiUJFGoREGwCqKAD5Z0MYgChyeblIk2eZYT+Zvn8eXLUa&#xA;Xa2FzfazqsEi6fHAnNOX2KtQljxLA0CmuFDX5NeUr/yz5JitNQT0r67me7uIDuYzIFRVNO/CNa++&#xA;2Ksm1Tyx5b1aVJtU0u0vpo9kkuII5WAG9KsCae2KogaRpSyW8q2UAltF4WriJOUS9OMZp8I+WKvM&#xA;PzLs7yb81/JE0UEkkMUqerKqMyr+/B+JgKDFXoq+UvKy3w1BdHshfA8hdC3iEob+bnx5V98Va81e&#xA;Y7Xy3oF5rV1FJPBZqGeOEAueTBF6kbcmFT2G+KvPPy60jW/NPm+f8w/MNqbSIR+hoNlIDVIzUepu&#xA;AaBWahp8RYkdsVes4ql2o+WvLup3CXGpaXaXtxGKRzXEEcrqBvQM6k0xVHvDE8RhdFaJl4tGQCpW&#xA;lKEHamKpND5G8lwXH1mHQdPjnqCJFtYQQR3X4dj8sVTS7sLG9g+r3ltFc29QfRmRZEqOnwsCNsVV&#xA;Y444o1iiUJGgCoigBVUCgAA6AYq1cW8FzBJb3EazW8ytHNDIoZHRhRlZTUEEGhBxVTsbCx0+1S0s&#xA;LaK0tIq+nbwIsca8iWPFEAUVYk4qp3mkaTfT21xe2UF1cWTepZzTRJI8L1B5RMwJQ1RTVfAYqiLi&#xA;3guYJLe4jWa3mVo5oZFDI6MKMrKaggg0IOKoeDSNJg046ZBZQRaaVeM2KRIsBSSpdfSA4UbkeQpv&#xA;XFXQaRpMGnHTILKCLTSrxmxSJFgKSVLr6QHCjcjyFN64qqWNhY6fapaWFtFaWkVfTt4EWONeRLHi&#xA;iAKKsScVU49I0mLUZdTisoE1KdRHPfLEgndBxAV5QObD4F2J7DFWEebPzC8iW2p3Gk+bNImMVqwE&#xA;Nzd2Pr20gKqS0ZYN+18P2cVYprMsX5i3ej+XvK2jyWflayu1vdQ1B7cW1uQqlaRKAATwZhTqT2oK&#xA;4q9txV2KuxVLPMujNrGjXGnpL6Ly8SjncVVgwB9jTFUH5M8tT6Bp8tvPOJpJpPUPCvBdgu1flviq&#xA;f4q7FXYq7FXYq7FXYq7FXYq0yqylWAZT1B3GKt4q7FXYq7FXYqkXny5uLbyVrtxbSvBcQ2Fw8U0b&#xA;FHRliYhlZaEEHuMVdeeaIrW5TT7ayutV1BYFnuILMRVijaoVpHnkgjBcqeK8uR8MVQ8vn/RVt9Pl&#xA;ihuriTUppbaC2ii/fLcQA+pDJGzKUcFSDXYdSQu+KqsfnXTFstTub6C406TSOP160uFRpgJQDEU9&#xA;B5kf1K0XixqdsVW2vnSF9VstMvNLv9NutQWR7X60kPApEhkcl4ZZVUgCnE/F7U3xVbb+e9Oma3l+&#xA;pXcek3cqwWusukYtJHduEdKSGZVkYgI7RhTtvviqI0rzZb6pql3YWdhduljPJa3l8yxJbxyxV+Gr&#xA;SB35UFOCtSo5UxVDah5o1S2852OhxaVNNZ3NvNM90pt9zG8C+onKdD6cfrH1AU5E04AiuKpNonnc&#xA;2VlrMt5a6hfW2nanqK3uoIFeK2hS7k4KfVkSR1jioaRK3FfDFU2v/MWlaXqet6jLNezrp+mW95Pb&#xA;IyNbeizT8Wt0JX963ptzJNCOOKomx85WlzqFnaSWN5aJqQc6bd3CRrFcemvqEKFkaVCUBYCVFqBi&#xA;qBufzI02Cxl1P9G6hLo0chiTVI44mhkYNwBRfVE3AvsHaMJ74qy3FXYq7FXYq7FXYq7FXYq7FXYq&#xA;7FXYq7FXYq7FXYq7FXYq7FXYqkXny2uLnyVrtvbRPPcTWFwkUMal3dmiYBVVakknsMVSyKefy/5j&#xA;1K7vLK6nsdWitpILizt5rpklt4vSeGSOBZJFrQMpK8dzviqX6PpOrDXdM1S4spIFvtT1C/aFlq1v&#xA;FLaCGL1itVRn9MEivVqdcVd5k0XVrvUfMstraPMwXRrq1QrRLg2Nw88kSM1FZqLSlepFcVW61qkf&#xA;mDzR5ftLe1vLVJIdQR57y2ltQry2jLwCzLGzlepKgr74qhtC0jSv0bp2j6tpOuyanbmC3ubX6xqT&#xA;2PKAr+/WR5ls/RBTmq8q02C12xVlnk+2ubeHVhPE8Rk1W9ljDqV5I8lVda9VYdDiqH1oy2vnXRNQ&#xA;e3nls/ql5ZvNBDJOI5Z5LZo/UESuUVhE3xkcR3IxVL4NOvx5E812xtZRc3M+uNbw8G5yCaacxFFp&#xA;VuYYcade2KpVr+karLp/mdIrKd2uPLVlbwKsTkyTJ9a5RIAPidea1Ub7jFWVeabO5uNW8smGJ3jg&#xA;1CR53RSRGhsblAzEfZHJgKnuRirCdU1C4078rj5autNvE1KxihspmFtILYrDIo+sC5I9Aq6rWgfl&#xA;U044q9YxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxVAa/9U/Qt59b9&#xA;f6v6R9T6p6nr07el6Xx8q9KYqxny39V/xFD+lf0v+mPqr/ov9M/VeP1eq+t6H1P916n2OfqfvKU7&#xA;YqzXFXYq7FXYq7FXYq86m/RX1mP6/wDp7/Df19eH1v0f0f8AWPVHp8+X+n+j61OPqfu607Yq9FxV&#xA;2KuxV//Z</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:HasVisibleTransparency>False</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:HasVisibleOverprint>False</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>297.496815</stDim:w>
+            <stDim:h>69.293882</stDim:h>
+            <stDim:unit>Points</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:Fonts>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>MyriadPro-Regular</stFnt:fontName>
+                  <stFnt:fontFamily>Myriad Pro</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 2.106;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.58329</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>MyriadPro-Regular.otf</stFnt:fontFileName>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>Roboto-Light</stFnt:fontName>
+                  <stFnt:fontFamily>Roboto</stFnt:fontFamily>
+                  <stFnt:fontFace>Light</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 2.001047; 2015</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>15506</stFnt:fontFileName>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpTPg:Fonts>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">logo-generator</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <illustrator:Type>Document</illustrator:Type>
+         <xmpMM:DocumentID>xmp.did:812e1e12-527f-a247-90e4-e9e0b49b674e</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:e7b62314-7328-4e31-8909-a181c5662948</xmpMM:InstanceID>
+         <xmpMM:OriginalDocumentID>xmp.did:812e1e12-527f-a247-90e4-e9e0b49b674e</xmpMM:OriginalDocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource"/>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:812e1e12-527f-a247-90e4-e9e0b49b674e</stEvt:instanceID>
+                  <stEvt:when>2019-10-29T14:43:20-07:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 23.0 (Windows)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+endstreamendobj3 0 obj<</Count 1/Kids[9 0 R]/Type/Pages>>endobj9 0 obj<</ArtBox[0.35997 0.000900269 297.497 69.2939]/BleedBox[0.0 0.0 297.497 69.2939]/Contents 31 0 R/CropBox[0.0 0.0 297.497 69.2939]/LastModified(D:20191029144906-07'00')/MediaBox[0.0 0.0 297.497 69.2939]/Parent 3 0 R/PieceInfo<</Illustrator 32 0 R>>/Resources<</ExtGState<</GS0 33 0 R>>/Font<</T1_0 27 0 R/TT0 28 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 29 0 R>>>>/Thumb 34 0 R/TrimBox[0.0 0.0 297.497 69.2939]/Type/Page>>endobj31 0 obj<</Filter/FlateDecode/Length 2381>>stream
+H‰lWMÇ¼Ï¯˜£|˜Q“ý}µb0`AÈ!rXØr‚•ËþÿpU±gß{+a}Ãùè&‹Å"ûýß>ìïúöïÿòaß~ÛÒÞæé³ì>ûYfßeùyûçþyKgNm¿ÿÿåãöþ¯ÿHûÇß·ßvÛþl¯7Ûó8-·¾?Úø€ÿzZiû¯gÆòçpXv–<÷cœ‰oo‡Ÿuø~ÌÓ/•3õF«§Îš/+óÝzzÆKægouáÇ#{Ü˜ƒ;ÕÄçvNŸ»!ìdØß>Ï§õÊ3~2¼™Ú¡—Ë°³fÓ‹4­c•Î]Ò™Ò×6àÝËöëöËö÷;Hâv³½¤³+øéÖa Pþ†Gõ•ûðp”Ë~¡]’ñ£œ/{Ì;‹Là“ÏÚœŸ¹U®\û$Ü¥˜nÂÂÚýlmÐž|:ÏT™r¬4QiaZãË–Ï>ìºq ôÎÅÊYàØefäJK/Û˜®L¿ðùD"¾ºUÝîlR£™ò×HÄŸ*óôja}PËh¦‡ýLEÈ£v2dÇu¤º8Fœ€ƒLgK²Ï©åÀz9’jæÚ@Ü›aäÝñb¼7V(‰”CÒs}k¦o°`Âµ‚l–Œ‘¥ÎÄpÀU~‰2`ô³è NÇÖ¤Ogp&ÈìEõèÁ¢ÖhŒÞÄ×œÄåŸ49A`ÚŽl{ƒ0#ùaôì¯¬eIgN—	i ‡¥õÓq/ÕrÏ[9Ýc 	Î#ï$€9—}à1·†ÿ ££²2â¬•k7$ !ßÉÒ¡-„ÐÁ
+–ŠqC€°rŒ5íQ}¹é,ÄmÀ.s€ËbÏò¹uåt6…Ü«ˆàÈ²UÒ¸N1Z&½ºL$"BÌ@Ù!\¤BœIÐ¹èG_eÎJ§/cj:ÂvÂ˜O/ãî²éhnƒÝëÏß‰¥baËZTºŒj~\Æó õÈ3ácõxÑ°Ò2r«ÊB/…5Ô¡z	ÿ‡tyŠˆ]’b½j\Ø7ÍC©—R4$µ6¢®ùÅ`GzÚEÐÿ×j }° SLë™&m1¹^ƒL(7ÊØÜBR§“ÁÄË~Ù(y5Þž H‘c!6!¸IeÁ6u’µEv\dbA—~³'@™ZŠù{ÙºÄãp¸ÉªrpñpVú'nQÆÙ³JÉcÙ®b•:&1¿(¶Ä†•Q­Dû›ôÃÑ\à.¥äµéóæ¦½¦³&r‹SÏ‘O½%@XH6UÜÙ6X‹•H:U-Ú_—p²w¶<d(x§Åþé Ä¬Ñ[‘]Šd›ME¿efdŠBÏêAÍnÀES<nEú†®:¸¡h*ÈzßC—È2ÚW&¤®—.áTs]£Úœ’¢Ö@P*µr0ËbhÍGØò’$gP†Œ¤öÐPUUï‘'Á«dAS.‘ø$Zi¨£05”2ÚJ›<ê%XÏ4›Ð¦üÏxÎæD
+äÈòÔöàÊºEwF˜ìk^E"Ê^à¡e—ºåÕ¿z½!ÆöI>½µ/¬×ëoLøgþ­l6È»S¥á9™rßäŠzh4·TP¹hHÉX*x?f¾žAaÇ fuIœÜ‰m!Ëè²¼ï%_}ë“n°×i¤l·±ó¬¶Ÿ„i˜ª8õ_ÊyŒ Iãç¤"ƒ›~ó¼Á}â¯qRÔö.	Tü.…ç¬ÁQíUã¹¾$nP‡FYN~3±…Çëqƒý½Eì€Ž¨ç£6uIVÍ´îgÑÜ¥qXØåTê9‰ÎJo"¸Ë±·ÙÝs`iãºñwP–‰-Í¯>Ì²®¢ ~h)œ$Ÿœ`ÐÙg‰{”e½pJ±” Á	m+ñ[¥mŠµ¶Î³—uÍÙ…sF×’œ6PÌ0R¯h¿]È¡05uIÈ§Â.Ms	^.&á™âÚÔIJòe•èö*6Žq0HeÉb@™t‚HAÃHÆT)²±+«‹q’‘8½^ÆIÝþw¯nÀçÎÂ x1>NÚ0¿ŒÀÛ%½¢¸ÒÞºGï’ºk¬´.çk×1,FK_]Ècòe[ám“e”™ÌÌëYØ€I0wrz ïc7UÁÌÚ1{Œã9¦Ûég-ÓpžâÐ#ÆŽ¼Žv³èçq”™Æ™D§“*„ñæ´x³K•´ä>ZŒ¹E3"bé‰cÚ3âW
+Ò°qò:4È9;±MDÉ8©u¢œÐ#¡mÁÉ^Á7âð—5B¡”=¯¬Îzå¹A¿}ÈªSÈP-™¹¸Ï*E‹Ç±$il“ò)<y®4a œYS¶$LmSópYrÙâp¸|¯ èè¶æ9.°>	ƒsk²q™øŒ]->£>¤z[”[ö±¾§7ÈYxCWÁËÕ‡8ºÎ³é§7à“Šù·cz{…d!²"'	>Ñ!Ð®	™>Ë‡ DÃGÞ —ëG„`D¼GsaqëY€± \`¼¼ÀXÛŽãÊN rÜ’w‹$Î±Šïž;:’æÒ¸~àf{³óÈ‘mÖ»€i"†c!š#Ô©Dàiªú®Ýmõ'¼T$`µ­¢ì’™YÑíªŸ©’÷Bªº³F‘ªÉ…´¨éøF±¡¡¼h{.lŠä•Žtˆ†´Œ'\ñ·DKÉ1X•õV\iqžG!~5%ðlÞšdŠ²^Ø¬«º-çâ%29‰°IQ§¦ä±PÄëX±Mºn!^£5)5$- -@Ç4;1ò°ëÛCVK¦’•ÿ?*Æiö>œ7r¿K+—Î1V›8:ªÊn*qî”—l19\¼)Êüà>Ò2W'JÞ—ÊAšÐZÔ³¤Ñ’&/Àšk¼È#%2Ö¤‡<ždÕ3²4VÛ–¤³fR7INÃƒ‹MOr^'IƒOE§È{U‡5r¼aj+|6©ñ‰Yô^B>J•ÃÜµÌ5þè´b%t™RÝ]×ƒ³…®¹„7•›‰È[æjÆ9^j@×‰Ê	,¥h­·Ô}ÿ´qF$¶·ÿÈÞû'ûs÷ôË†ÓL7ìÉ®k­€’n‚=}Úþõîé»¾¿ûõ¿Ÿ?~÷ï§±ÄÓZÌ»V¸®9uõž8HºÊÞ½üÿóÇŸ¿ìh‰§ÿm?<m?üôa‡›
+0 !%â
+endstreamendobj34 0 obj<</BitsPerComponent 8/ColorSpace 35 0 R/Filter[/ASCII85Decode/FlateDecode]/Height 8/Length 135/Width 37>>stream
+8;V.Y>7JA5#SVk5r87Z5pJhO-1LAbU[Z\G&'[#+F0eS8_;,N2*SAL=7(YoD[48R35
+%j=?cX6a50>9@)5Hn!dKjshTn_K)-:qb!lVA$0[f#JlgVC#2#nmpA2,9GO`3!19L^E<~>
+endstreamendobj35 0 obj[/Indexed/DeviceRGB 255 36 0 R]endobj36 0 obj<</Filter[/ASCII85Decode/FlateDecode]/Length 428>>stream
+8;X]O>EqN@%''O_@%e@?J;%+8(9e>X=MR6S?i^YgA3=].HDXF.R$lIL@"pJ+EP(%0
+b]6ajmNZn*!='OQZeQ^Y*,=]?C.B+\Ulg9dhD*"iC[;*=3`oP1[!S^)?1)IZ4dup`
+E1r!/,*0[*9.aFIR2&b-C#s<Xl5FH@[<=!#6V)uDBXnIr.F>oRZ7Dl%MLY\.?d>Mn
+6%Q2oYfNRF$$+ON<+]RUJmC0I<jlL.oXisZ;SYU[/7#<&37rclQKqeJe#,UF7Rgb1
+VNWFKf>nDZ4OTs0S!saG>GGKUlQ*Q?45:CI&4J'_2j<etJICj7e7nPMb=O6S7UOH<
+PO7r\I.Hu&e0d&E<.')fERr/l+*W,)q^D*ai5<uuLX.7g/>$XKrcYp0n+Xl_nU*O(
+l[$6Nn+Z_Nq0]s7hs]`XX1nZ8&94a\~>
+endstreamendobj29 0 obj<</Intent 37 0 R/Name(Layer 1)/Type/OCG/Usage 38 0 R>>endobj37 0 obj[/View/Design]endobj38 0 obj<</CreatorInfo<</Creator(Adobe Illustrator 23.0)/Subtype/Artwork>>>>endobj27 0 obj<</BaseFont/EOUCVQ+MyriadPro-Regular/Encoding/WinAnsiEncoding/FirstChar 84/FontDescriptor 39 0 R/LastChar 110/Subtype/Type1/Type/Font/Widths[497 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 559 555 234 0 0 0 0 555]>>endobj28 0 obj<</BaseFont/DKFWHS+Roboto-Light/Encoding/WinAnsiEncoding/FirstChar 32/FontDescriptor 40 0 R/LastChar 116/Subtype/TrueType/Type/Font/Widths[243 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 517 0 555 549 224 0 0 224 0 549 560 0 0 336 0 321]>>endobj40 0 obj<</Ascent 1056/CapHeight 711/Descent -271/Flags 32/FontBBox[-846 -271 2044 1056]/FontFamily(Roboto)/FontFile2 41 0 R/FontName/DKFWHS+Roboto-Light/FontStretch/Normal/FontWeight 300/ItalicAngle 0/StemV 56/Type/FontDescriptor/XHeight 528>>endobj41 0 obj<</Filter/FlateDecode/Length 12119/Length1 33522>>stream
+H‰„–tMWÆ¿½Ï>ÉÙç"	yrÎ¹—ˆ¸‘©·z”¤eÆ«Ü¼eRU–šz4¥Êh«C;³dª˜Î¬Žbt–Ö£>ŒÇˆœ›x]A=rïüo’eYkÆê¹ëwöùï÷ùö>û»` šb1dfŒIéòñìÝÉ”s–ÈÊ-Ê.æ_ÍXÀ‘“;wŽ•²WühB`|AñÔ¢Ò®mß¥:û¦ÎXP L?ph¶I-ÌÏÎlO)"+©~·BÊpìXDµ¤¸]aÑœùƒOþÔœbê?íÊŒY¹ÙÈLxÑžâš¢ìùÅaEÊŸÒhªoÍÌ.Ê¿’œ@q7€çÏzyN ÈqxmC°¼xv~qIJØ8ŠÿJóéEÌbIP¡©ï«])ÇlH•oPÀ©A†«z ÎRztãaÃÐÔi9ußZw[`›‚e¢—ºý”ú.X}‘Ñ7Âõ`CcÉ“—Ò˜Šÿ)ù—Š„Bƒ„šÐ*5CÂæhA#F!1h‰VˆEk´A˜4/'\h‹vˆG{$ Ñn$¡’‘‚TtFtEžA7tGôD/ôFôÅ³èGo= 1ƒ1C1éŽ‰ç0
+£‘L<0cñüã00“ð"&c
+<ÈB6rKš]Ó®k5Ú-í¾æ—\ªRÈ©ÉP)¥C6•Md3&#d¸l.[ÈH-£dŒl%[ÊÖ2V¶‘qbf#˜&f`>–¡3D-æbº:¯c©Ú/«ƒÔÁ(Ä<µ—ÚGíÍ‡¨ýQ„…¼'~ƒxy˜¥>‹­ê Þ3±Hk•ÚeÍ§Õá]¬S„Gˆ©"Gäb¹:Tš²L,'ÄQÚ1Ô-¦cÈ…b¶vU»­]Ñjµ›Ú]ížö“vG{¨=¢7| !™@›ÇÞÂKl9[ÁV¢„•±Ul>„L›`&mƒP=¸W$­á«ØŒíøÇœ@5nÀÏÂX‹g	,•õ`ýÙæaSÙ«lÛÄŽ0›U±k,Àcx<ïÊçðWø¾‘ïåû”yJ©²BY¥¼£|¤ìTþ¦|§\ñ"EôN³è=VŠMb«Ø%öˆƒâ¨8.~ÄeqGej¸¡¶RãÔ”ØÏãîÄf$)F_£ŸQj¼a¼ol2n3ÊŒ3‡˜£Ìqæs’9Ù\d~fî3¿0›_›'Ì™gÌó¦Ï¼aÖšL¿%­H+ÊJ°ºZ½­>ÖPk¸5ÅòX/YeÖFk›õ¹uÖ²­KV“9gˆS:[8cœmíng²³‹³·s”s¹ss­‹»B\a®æ®X—ár»Ò]Y®üvmã&Üpg¸=I¥É·|¸eSyYùÛåŸ”ï*lMÞæÙ–ß=ô0ÄßÉÔõßOƒÞéýé½ð%Nâ"j`á¬9kÏ:°Î¬'ÀÆ²,VÈJÙz¶™}É¼¬š]çà-y{žFzÏåïñù>¾_)Q–’ÞeÊZå÷Ê.eò½R#Ú‹T1TdŠ\Q,JÄ*±YüQì{Å!ñí¥S¢R\wUNz7WcU#vgâ0¸ÑÁH5ž5ú‹eÆÆfã–	³¥i™éff£Þs±ùs¿yÐ<b3Oš?˜çÌ
+óšyË¼kÖÑ¤“ÞÑVŠ•Fz÷µ†Y#HïbkŽµÚÚlm·Î4êÒ[­×;Úi8ãëñ„ÞOèW¯wµ{´{bRV§Š-ýIoÞ«Ëw–ß#½S·å]g¤7üéýˆô¦Mx¸¨¢ôq¾ŽD¢aÑ†ˆ%"‰è@ÕŠ”}Ù›H%Úùé¤÷F{øw—0äW!…ÁÔ¿œXDdéµów'¨¿á¢ãr-±Z]ÔÝ!j‰šKÅÕ)Õ4kS‰lÂCL ®^|µ¾[¾ßuŸÏwÕwÅwÙwÉWí«ò.òUøÎ{gûÎúNSˆo|'½#½#¼#ï‚|ÁÛ Ïòº½‰^ßÛÖêev}×¾hWÛU¶mŸ¶OÙßö1û+ûŸöûS{‡]no±{T¸í$Ûm·³vTåýÊÊÊó\çžË>­üûþ©û?¾çÙèùÀCšxzyzL¹=ù“O:Ð*><¿I¢×ú…zÒWX‘C=zñ.±ã	ögëkV×ßkà‘õHG‚fÏ“‚Ï<­>¯O÷bâc2,ò2¥1– ±”7	CÙLü¡ÞÒh­r`åðc“;ØÈñFHCåìÏÛò]CÝÇñÉÆöÁüoÒúüãOíáëŸå)-×?½Œ<Ã&×¸B.àz^×ªÈÓ=@«ÓüX‚¥Z èär
+ÞÀ2r:•¼.”ÜN’½IîEþCÞÖ
+Ë±‚ü­uÐá¤•š«ð–V29JŽ–2S>/_ÀÛX5r’|QN–S¤GfÉl¼ƒµ2GæÊ<™/äÔ ‡É¹rž,‘¿–å"í¢vÉÁëOºO±»°r(z	ÎÐ¿¹sø>Ü‘èèèp;’pŽdGŠvCêr\/+7È9ò9_.ÀT:ÒÃaÃ‹*r¨‹¸äï˜ÀF±ÑŽ‰úã‰´[Ü<É1‰wâÉò&O‘·ämYËSygùP>’u¼‹ôË ïªCg<Mçü]áÝt¡«¼»Â{ðžz¨®éR×u‡ÞDoª7ãƒôp=‚ÖÃø>”ãé|8ÿ/ÛÕÜÔuD÷í»’¬•d$[B€øH6°%6¶cc‚Á6Ì7Trˆ1Æ0Ð˜BC# „ÉPJqR†tM[r¥™vD§ÒÖüÂ”Î@CR |Ã·|,wŸ„ y3ûî;÷½·{vïÞ{÷ŽÂ
+JÁÑ8†RÉNêHN‹ãp<N0M6½‰S°ÚTešbªÆ©Xcšjª1M3Õâ4¬Å:|§Ó8ê„3¨3Î¤.ä¢®ÔgálœC=h<¹q.yp¥Q:Î§žXp!õ¢î¸ˆ2¨7õ¡¾”IYäÕö\òQ?\?Ãwp%eã*\ïR\ƒ¸ƒ4 ×Qåâzˆ(&P>þ‚
+p+½D…TDƒð—¸©˜^¥Á¼—|„¿¢ë4‘&áïq7~†’^£×ÉO? kølÂ}¸Ðº‰ñÆ# J<ŠÇð8ž [ô-½A“é+ºHoRÝ¦;t¿Â‹t…¾¡)TMSékú/^Çx“æÐlšKóh>ÕÓ¼…ßÒ%ºLk¨oã¼‹÷è.ÝÃû´–î›êLo™¦›fÐ+úŠLÓFÓû"Kx…Oô£
+M/Ó*¡¡4ŒJ¹Îè/ˆ‘KeTNçè<ý›¾ ô¥(òD¾(/‰B1L”Š2®H†‹ô?ó1±P,¢á4‚^17Ÿ07›OŠ}b¿8@ÄAqˆk”#â¨8&ŽÓÄ},4ŸâÊuW—Õ\inçêsÏ•ƒÜVseª­7öh5ØqX[ÁÝ)ªL¢ìbX¹J·ë;C¿¬ø¤èôÿâšš/	Þ
+iï)Ê{ˆÒºZ–uÕ)U>©xÝîò™eR©öIôJ%Óã“ª×=\ª½†¿êO¸ƒîàÈÚ ×73¦ÖJÑ+Öò‹º` Û-a¢&ß'ù=²$àj¬Š|RhjDLM0À
+f=U0+¦€ÿoñI·Â-ÕŒñþ	~¹¢Ì%KÊ.Ç].÷Ž÷Ë½e.O à“úvŽÜ.ŸÙ)ÎÖà•úLŸLŠk˜è—%.	`0ŽÒ=rE0è
+²mxïó8¢À‹%‰òˆ²b|ìÍŠtKëHçŽÊ|Òè­˜è/gŠ¦H^™Yî“&¯ÌâÆìõVÜÁ‰þ=%|ú™I‚†Iþ=©^®¸d:+w7D¬ÐÞ§yiñÊ’†ˆ*ý¡,(sí,õrYÀÇç"m'êÃã«òhùdÔæ‡ÍV›-¥Pš­šµ»>v7Æî–fñr¿ÄlW»¿ˆ` É/Âÿëâ!Þ$ÅIçÂæx‡%ÞV™|®ÿ ÇæQm
+×íªGÉãŠ¶OK16åGoDÿ¤˜/¢*ØÒ¢“~­3´,ÇÅm¸¤¥
+«°ŠëÒÊÖkê1–Oo= .lt{4ÍF«ìô”§‘©»¼È³«1Æ kvÈ¢HÊò{Îºîò'ÖPÊ3vÄ?2ZCžõö KËÈÈË˜ŸŸ›“âpxöŽ¹9ùN½’¦7xò22pHð‹eKÏþtß¥'ONo¯þ ¸bUôæš=v\«Ûeo¸³%«ñÑÆè+¥ÎÈ½ác
+ÿª>Ùÿ‰¥±I«±çD'¨Ÿ³/]ø´ùn¸gï>šùžVizê‹ÊôÕ6_ôômÀÄÀd}
+œœš—:Õ©…»ƒIk¤É²%z{)ÖP÷„¨ÖPÏDgS¦äæ8rmv}zZFï‚˜¯yüŒyNÍñ[FFzš~Î—;¿H_ÿÍÁÇ•¾ýÙÏw©‹ÎýùâÒ[ÎOÎühþ–]Ø;ªô•Ï¼[7é•ÆÐ‡Ûo«îÄÍýÊƒs¯sÖ¨Õ¼ ¤Â¨°Ùî`j S²¿ë¶!ù)°2°jž‚jÐœaöæDöŠ6H¶ô8K?ä*©ƒ"swÊÇÌ¥«çÿ¶ïâÅêÊ©³ššZŠðÀ¦÷Öý¸Å¥­j›¹º+Ò5ñ¼0Ã°Þ’¬é×[¥’˜ÿ/æ•–Ò¦f^—@ÃÃfÕù9íú´%mÉ’ÞÑ>ßh¯(R
+Ó²³ËúõÓR>å[›W¡[‚÷Fâú45±õ·-vœ7©0)ly;íÁˆç8¶$ImQ´1°iQTD’æ¥°&Î
+Ž¢ó»aT’Åà?ÎK£(ÚS;31Œ¼w@|~
+7së Ý¡<,z¸ãdjó÷p4303“PjBJ2×ó)©Ñ‡Ã®ç<„xæóŒŒ‘sT.=¿þ¬b^znÃ?£w–úxÇ¡É;go?Œ¾ÆGë¢'uþðqƒ’ýÈø÷‡:—_ðøH{ñæ™#Â¦ÖöÆ(=¶ç& C³5„†g‹Ìzþ›ÃÖžrNæëÄ÷3²ê·yÿ§œÊé¦~nX¾¸¥³(úÝ^KÌ¾³õŽÔL'wt¶ÛWØŠÒf2•Aj°0°hö•Ø:ÙüRg±†’ž›ÚÒÖ,Sš™™-×‘n‹M_§6­óléy¹6åõ†Žî^ªËžð“útã¢WkZ²+ýTcÛ¸OÕ(ˆ— ¨Ò¶uJ‡â{Ð9)–‚M·l±>ùà´îaqËkeÒ"†FþV‰yI5-g hèÃâ'9Ô5ñÜ¥]–"u½¶Å/åv‚‡­86ŠOà51é®À\qæ(“a1n€õ\±xÔ:è&VA…Ò Å8
+(W`“êƒîüý–0ËL––R–],ï°Œa™ÅRÇ§»·•P,œÜ76‹^°LÝ“cahe=— ¢Ë•ºÁáj("V0^›t¿zà´˜#tfî/€ˆþ¿ÛÍ2–‹ë±v©Î¿8 uÃ`‡¸	=^,¾†q:‰CP©\…ÕÞÐŸ[í„8Fý!(8¦‹‘PË·‰P%Â‘•¸†ˆz~®…FålVN·þŸër®ª¸ãø÷žÝ=ç‚‚Ò±Ê+€±B‘:Uq.F¨%PSLˆ„‘‡ &¢ò‚y¨!Š"¢`EL¡J‹ÓÚŠ#ø¨¶¶Š"ã”©´PÍ½Þ~Î¹W§Ó?¾óÛÝ³»¿ßþÞ§ÁœˆÆÛƒm²7«ÉÖêºèÜBÍñv1ï¢›½õÊá[ƒyOý¸F™c*4‡Ô:ÕkÓØØAí†vrK´Žñ{½n·ëUê^Eç}Ô=¶OÛ¿¨ÜÌS³*M½šÍcªµ¥ZêW°^¡:ãc«KtµwLAÂ­¥¶F­ð™;­­Øtëw˜‡t·y{¾¦þ™ºÉ¡…f‡¦Eêfáêï·zÁ>«ÍþAl¿»¬Ñ8î*±w ÇFÍqw"Ó±çTtz±~ìuS÷º®Qs°Xs‚›T;¬möaïEÏïñ¸8ºÜª)Øt¾[§;íg*sÕÊwIö¼«ÒHÏ5º[Op[?¥™¶%½ÛkI¿âÚ´ÎW®ÿ†š¼5:'´{¨ûpŒfªÝJïvµÊ.Q‰_Çýšá¶qwÈ»,ò…bÛUóíblÐ®Þ‘]Žª»×€¯…>2Ÿ÷<«7IuîZmç|w{@}B?1ÿÒtw–®Ëlî²çh
+ò†þ}‰õ5Èü•»áã¥·½÷A«z‡1Ô©“öÆ—jo°½á»øOw6zmÔ¼ø‡øéÕøï!UZ§[Üpæ­ì»Ÿ¿Ž÷¿ßSšjºðÞF5™!ê{+½&ŠŽÑU:=>ŒÈG×ªøü­Ô|©©vFb×Anü¾UžýB½£ÂíëøÇvé^áìøQO/Å¾ÑìËEÄi³nC7Œ)ÄæPû¼fDèG¼öFÄ‹-AöU»åª¶Ýt½·VÃÂ;£8Ù«eÈÒË¾	ðÿ0nB„ºñ†ªÁ[©Jïu7•ç-ÕËìãhC›ìé¶3·ªÑß¨¿Qõa|W½BÑ¦ÃÁ0øŒÐ}ˆ;3†=ßãØy½Šàc¿COãƒ³1)üx´¹|«FwsÀ]šm'ƒ\]Ê¾§Q|tãÍß¨ÌôGöŠ›è(|s¸§§Ê‚Ø§|ŠnoáÎË”Ã_\Ž¿ˆüq
+¿zFÛM‹.7/©ÜYõBï½Ìµª
+{]ôSÈ÷f+Ù«lôÄ&ª½Æ¨8B_]Â;‰>O*a¦kŒ¯f¸›+@µ1cõ€>a½Ru^gMóÎÐÑ<|À8\‹­Wy„~ÙûFªø\ÁÞ™ª'ÇmôjuEè—¦VÆiQì‰ô(o®ŠM/dº™OãWIdõ4ÉÛ„üÿ“«§Œô”wD“M9{K¹ÿ.‰°2‹¹jåB·7 ã43’üõ+•zƒÙû? g{ŸB—(!%?”R[ ; Ý\rèe}´z+ôp7xšùz0œñÌ¾hïjP’9“Î‡æÊoªÈaÏ?¤ï/a|
+œÎÒ7Yû˜3gBgdø%™§¦gÑ	¬eíPvfemÍ¢,ÊÊ¢¬“:Š c¡yœ¯ÊœO™;R¨2EíN:ø"sz
+cäJ•CéR²üBÙ
+2o	¿'g‚å` x5Sù“¡Œ!ÿf(÷%€×AæÕ±R]“yO~©óÀUYÈ 9+;GOÉã=Gö€wòkpü=;Æ^©UàGÙµÓv&¹ü£L65<v¯®Åîí³/¨-Ê?aŽƒÆöPßýÁ¼­-a]³zÑmP›¥…ä±±äöúƒýaŽw{5ÍÝ¯Zú‡Evq´_»Ì?UÕò–ù\EŒ[ìƒª÷Êµ'¬#äùÛíïÉaáz‚3óÙö'	jÈRÍ#‡/ö¨aß±€\ºY«íøôawHUþxtEÄs˜#ÈS?äfú{†¶Òô³—êr÷‘.¤å¦òfî0«"üŒ¿ž&KnŒêcØ÷„ôkpã´:>OÃâ­j÷«˜·ñf§]îOJÉ/¿ƒ×Nís-ÔR§‹Ü—šèž×snŠv³µ'¨×hú”¿SíÔÐÝÜw_0N‡í1MçÍ3ÑÕ“æt¹IÃý<j^z¶eè} k+Ðí{z2šòd>½C•½ŸùÍõKÔæWªÅuVžï±o@oþ
+è4júMéãÌ+ýwÔß?Æ™ÛÒ_„÷çj»¿IÍ6‘þ8¨#î+=N`GªGàë˜ïëUµš©ß-ñÇt8¨ ßè¥ó9[“ŸKèózR_"Û‡ýIp6wÞÈÛ²wSgWÚ!ÈzT÷àg[Á2ü®lc|¡ômïvãgY\Wýšž¶ÑÎÂW–ã-zÑt¨%˜Lþþ¹º»|k	zùTÏQZý…šäæžÀÆuj‹Ÿ¥ç±KK<_»èUZÜIú´—‘ï´.2_©Ð?©<w±zÒcì°5×]	-×fèã~gjøÞô©èî‘ju)Ÿ~«ÀmÅnø£Ûõèûsú„ÏôdÔ#ÑGD¸O=ÌÝêæ|¾S!>=Á¥‰þØbòÔ`;»zªöiŒ_­aÁŸµßo¢Î~©{lwÝÆúº\üsœÖ¢÷|ü¡ ¸œ³j`K}®ƒÍšxô‰=Ñþ?¡|zê‚øÔ\ 6dÝoë¡ÅØs±šÜéçìÓé§:_¦D|4=Ö»ºÖ6àÃMÜ_/òRÇØb4Ì‚¤oÈ±aî½7“+S‡À3¬ä­òVÇ ü¯«? $Žéçì(b­;þ†´«fÅ^ÓFs^}éŸu{‹õå`%}ùÄõÁŸB¬RÏ`ýÿJþd1‚}ã59Dè÷ößzÈ~¥"üNªˆžï<ßh´ù„:uÝvÁG¨3¢Øèñ¹Õè0ŽÌûÄö*õ6ðÉ©Ð—¨ù"š#JØŸPÿgót>µòEÖ;©ÊûÓà‘0E`ãðl=ûþÆž¹œG¿`š¹Ÿ¢ÑŒKø^–…Ph®T"¶B‹LWÎ•ezê{Âkç®¼,8ëÅ á·m*Œöé¿t—	pVÕÅÏwßöD‘¥¥D&dDE ìeÍMbÂ’„I¡‚ª ¡¥Z%J4ˆY*[Y¤´àTE¤jÆÝv\[m±.ôëï¾÷¬Œ3sæÞïæÝûî»÷ÿ?ÿsøý ó«éS?§˜ýŠ5Ë©ý¬g5Kø¼gŸi¯§€}'x¦Z½‰Ÿ÷¬|ÝLç|Ø=Ü×À;JsúË5ÇáÆ p†/B‡ÕÂ»³àŽI~•:YoŽp~7€Ç€Ã\«MïÂgáËàþ™ì§Öå=‰é¥Ì·z|gêlèÁN¦ž¶Z/ô^vý¹ø»/˜c=Gx¼M7‚;|W£ñJ÷¹5Öü5õ
+ùWcó‹sí~æäªè,MW0œû·c|»Iª=ñfÛ>¶onVóÄÃÜé«œÏï8ï²h¿.œë,çOÑÙ»C9ÿ÷”kðýöü‚½ÄW=ÿÏÎÞÃN¿ðnº8à€&Fõºq¹Ñ2Ò&¡YÞ;@Y¤3š–’/K€Õ§"ÐÔ"®×¶NïŒŸ½2Æà¸fñ:xžçÑ
+MVÿtæ7Z©ñ`oô«GÂº¿6ßñí¼Æ·Gg5¥ÇÚì5p.îOˆ5Ã3àãèš†Ð.‰þwösêù*üÃ-fš™­òÌot©Y†ïÜ¨™ÝèU{ÿ]µ•;ŸBÍÛg¾RG¸x…;D3¼NôïÅ‹Õj|b$6i¼ÓE£œ¶hßCoêÀ+*eÍ2³ÐwZGHü^E!˜‹ßS2Gú¦5ûJ-r¢žÉô ’KX9õ’â¿PÏf‘¨«-ÜUª÷®WßUM=uf½º%fÂU3Ñß“•CûSS®©fº›å˜ÙxËigCG¯vŽ¨&qL+G´Ñë¨‰"'Tœ6FÅÎf|Á0‡ÑÆô‰ŸÞf292™:?W#áŒŸ8K•Äû…àÝ+¼JæUòìýœåTàÝeÎvbì=ážDÿ çëîÑ²p}g–£Oòío·Z÷9}ˆã{ÙçfÚÛá˜!äÄóôŽú†¼K,!>Ð`&˜ú<0Ò¹Mß ^æ]§ñ#§yO©n³óÀ"0
+ûÞùYñü†óæd=Áæ5ñM=ù~ËS‘—“5?ÌÇñ!WÎ"n†Á]¼Q*õ×Rêí$ëEýlôÍ]ÚŸ,Õ¿5}j!ü2Ö+V¦Õ­ÍÒ¨¹{ÕÝ[H}Ÿ¯U^oÆï€;Yƒº“éžÀZ}ûÚò2jú^Þ3 ŒÏL«ÉÍc •y÷ìƒQ¿±Ä{_%Þ•øï¨šq:¬Ä/ƒ{÷«8Ô¿Pµ×½q	zÀÑlo±f»ŸÁcŸÂ7jL¨QSèÑVðÙ:jöGÔþåÔïÕç¿‡Žx½‚ó¿FÕ¢åŽÒ®ÔÏ‚Ñªv©ÂßËï6šéghªÿ¶Sgçû3Xÿq=f2Õ€Vn@c7øŸ©‘A›‘¤7[FÿÆ>R/ÿŸê•<¨^èÂ4ÁZoº‚NjH¼HÌ¬Ó}Þ4POÿ-e{[”ÌSvÚ@ú;;‰N~R×Ku¹u¿Û‰ú^¤Ò -÷±K‹ÑÐ‚4bò*ÝÖò«¸³uº"ŸªeA_=`ªÈ@ÎÍ`|ñØß]©z·T?NÎUµ	R+È«
+·Š3j§!ngŠïu›¡£~®à&r}4˜ÃGƒ9ŽÏ¸¯f
+¹2E•ôó-¼~Ì;§Qn=­Åú÷Âß»Ñ{¨[—qïm´Ç®râÔuãíè¤«h³¨YÏáþ­	ÞÇZÈîóÌù-±\YI£\4|êØÐÐ3•1¯üüZEæÜ9žÃm	o½¡lgï;„†yNxÃÆc·6u¹>7æÚÓà0¸3æàgãöíˆ³CöIìãìU‘¹Úrô›ñsÀSà`Üì‰ù½%š ßÂŠ‘žç\ÎÄÚG-|”N
+Æ-öÖÐÆ€‹óÑù^ºFz—ÂU¬óëpÎXtÄuN;x»—Æ:=»Zaßb9÷µœšÜV«ÍàÃ¸%&ò-œ×u7nyë|842qïýT—&FÐÎQAÜæY.t:ª7:ç€[ÀZ/èææ¯i×Åi—éÆ3–óÖ«ÿ1ÜÜÎÉ7CyŸ½_«?lû!í!Æ.¤¶Ý­¡=†ÿ*P7¸c‚»H%É:-óßW™õoî‹j¬I=íoRøc?¹½.€_üGÑH+ñ„Gà$ò8¸"ôN­Ès;þ&Þµ%ñÐSÝ¼ÃÄøJ|ã-èÄ?«g0x|ý¾Oû‚xŠo¼«mwª(­Tƒc´ŒÁKÕhóq»’×râ¥©/íÓ qm¼„¾)0+à$<«õ™al¶PyZ™Š‚‡TèFoÓö=Ì›„Oø˜ÍžáL7î{ö$ßg9-î/Iñú¦>õFh=¹ûP°AOq.[Ó&±ßãñþÙ³³‘Üû@ÙÃºÿÅqfˆ‹°?&³mì»˜HŽÔ‹ÿƒ½só’Æ9ÏO­é7FHÌ¥ÎÄp¿â®™£Bs=ï¯¦ß
+ÿ¸™Üçüî|ó<µsóÑ¡¥p]@Í÷ÀA°[ƒÈ÷G‰•Š¤£ðryr=mí]ìŸSy®~p^ûÃ¨¥EüX	G”Â'Ôçs¸£‚ßÓÀSh¦5‡Z—a6ÀÝ}x&¼Ážþ6ð…V¯·ñð
+œ{&ñÖÅ»‘˜š¥îß¨·SO…¾ÿB:mà¬µj‚zdµw£¾Ô,·žÚÄz¬w’÷Øöï ûZ¤ux¡kñ7×:_Âugàë*A»Œs*4Ñ[@ÝÿR;“ÙºŸ÷ÖâCj½ªA´sû©-ç·Ì½›Xº“{™H¼œ ~Nè:jÇT·:ë/Úê•pÞå¼'—ï~‚Ü¨Ôæ–›cÜ×x4àQZEð2ñJ¿å;·1ç6Þ‡‡^3ƒû©å÷aþ—§Þ^kâÌêÐî¼ç&õ²i³‰÷öœ}–~—e¸§8;ÎO˜á_yogÞD;ñ¡ºÒ·zâgÓW½ñ¬}:Û˜÷Óð´Ï(×«Ñ0?ïZ¬¬Wdk„é¨†´ãÚì6W:µ+Ã?Å·¼¦:¼c:¤«Ýµçfò5×i©žæ"Ó¨§["8+9‹yè“Î, ç£€˜õ;–œÝ¥í‰÷y.œ"/9·1ð‚2ÍˆÔ›èó¸'#¸\5Á%ZëÞ•:¿õp'á›N‹éß–Úí¥§v»·¦êð=—‡žÓú¦gñQ£y_äþ’<ùPw˜@›Qº5q’Ø:ÊþG1¿XýýºxÇþÄ[y½=ÒÚé±æFoŸÛ¡qË÷ÿß]“×[çÐ-5ÃÉÖƒð~…ù/ûåuuÅñóûíýí†‡ÐN`K+P+T ŠBi
+>0L™a((òlÐðJÀ¤6i Œ&4’H$	È#ˆºP5[GÚN3”l‡l'elìªX[ë@‹3ÙÛï¹{;¿,Y6ýóîÌgÎý=öwÏ}ó=ä–ôf1˜h&˜&ƒ'A5˜ ïÏ»@®LSÅê/ÆÑÐŠß“ÇŸ¦2‘AÃÅ@Ê‹1?!èŒ,ôÂûíÔà\¢ä˜ñl+·Ú(,Îáú×Øslù~ú6Þéïãš¿Éÿ…õ=ƒ5iÁÿÚi<4l.t_.ÎR	êŸ[ÅzZ¸—†îG³Ñ?Þ?D;ûèf&ÆÐ4h3¾·[¼Šë~4g¨s<ÙŸNþ…ê]áTáÞÝ  ùg
+ì*•§ûúÆ~Šÿ¾L»oÒWCè{:Æ¾	c‹þñÐàÔP/ø;_õÇ~óXÞ¢1Û÷¡“ê±þ—#ÐÝhúÎvš>M¦@Ó#žÛÏS“ýÍÄ¼ <äŠÃ8WG}ÿÆ¿ö]¬A	žcÜbìJ·ŽÑ6ß.ÚŒµ‚:|ý†¶šõ«!Ôó|OÈjèú‰´ÒWH¬w‚<÷¾´ÙW¤¾W§ë‘.k§zvÖaXOG/J«K|g1_QOÌ§¾â$MË±î¢løX‹º´Òÿ*æg4<rb*­F|.JCÜ±>¤û­S2(ò1þ|ZÇÁ
+0ü,¹"ßúŠõ¾¬°þJ/Ù¥}€†Zge…o(DíõKë8î§Ñ ë¸¼Ìmk•ñs{9õ²ÎÐFÍaìl5Á.>Ö¨`,Øéûu Ì£A­~o«~·
+,³ø{úÿÿ'`8( {@X?Ë/ƒ• ìÓ×Ù¨cw~¯6Ôé÷sõûìC¥¦Z÷]§}
+ë1ð½…žwŠ=}Öjxë·OîK÷]¥ý¯ÒãcŸÑÿ«Ç’£Ç;\û–­çh´g<®=|­ÿ»Hß¯Ô×®•žyÜªçrŸ¾_îñy¬öc·ö©JÏñhýÝÝ7#ÇS=Îbm]?+µßî;{tŸõw«Ýoé6ÏOØy“6ú¾EuÐ3–ø¿Ü‘I# áj†+ï‘`À9ºÂµB:l1hˆãWÎ€ ÏŠcuÉ•“ÐLEh—£­y¹v,ž1Áwc_…|8þÒ±lD\^‹{Ehsž¾×|Vò¨ÌCnm†>,å5GâÛ\[ÊÝ8ãùÐŽsÞ ·?A~äsÇ·Ñ†˜ÜHÂ?ÚæœŽáç‡Ç?VÃ?hâ«Û ü¿Z­yFÇœjýÜµu8§í±ü$Ç n¶.â¬fÓhg.e0qÞ·k;YÓ'Ú®¹¸ÙôÀMà„!£à<kÖÃ×0‰½¨Úƒç$î\z@ù;âÈ.ØÓàtÀU‡&ÂúÀ4ü`Fƒ¿`Õ¸Ð_RËk˜†uâ1³/),bq5ï¤6¤4áÌ×1Œc;l;ìë°`a>o·ZåUØ·ýetZ¥ÚùAëŒ¬PzúŸw&5Y­8ƒ™ˆÙ­ô([{íWöEÚ¯4$æ'ÑŠyªSÝåµýèu;Œwcv¾¶¥º~ÊIic{(½“=Léj½±ÝµÐîiØïØ#jÝx¯xkY<„z¤…fª1ÐlQ"Ï(X!7'ù›ó¼«MþºèØ6ð;>oêì%ÂZËk±„ow¢¤s?.¬½:qNùÐŽ€wàK/°õšÒmˆ1§´\»‡DYº°¶óÂsã’8Ò•<.†õ¦Ÿ™ œè„äTì×¹Ð äÜ%ïv¦So{©Ü«žŸ×ñkÄ{kÞ·\?¸ñõD3ïµ¶R&ÇÕfM>›–c-wÚKé x±õaì>×ÔÈµÖ}újUÏø>¬¿ù„û\F‡x?rŸê›87¬ß¸Ç¡Ì¸ü^PùsDùÒq+DGÙ7uöÙ?ø¦bŸï_Ðóª¿<ô‹¸ â
+|ág¾´—Ï Îb-Ç&ë´¬Ãh/¿ãîçDëîok­Cý±Å·ƒêùŒ[+h"ûHGÍäÆ*í«ë‡SIO"žÂ×AÐµ=Ò¦Ðœ™˜WÔsðc±»TŸ .Ã|zRºävbtÏQ<†ÕCçÝ‚Z¸ÿ‹›ý`\ëÆÅ´V<E³ÙÆÛS(ˆõÉã¹ç±^cgÐ¯Ä$Zå…ûmÔ•kg“Äim¥xžÚ¦Žã÷ÁöMöó×‚<T{ëLOc¶_Òç[i“øæ(•MŒ“k`›R[oüìd«0ÇØÛhßáÎ?ŸÞÃþž4T4ËÏ9?‰d‡bÇ3rFÉÿ[^r÷Ÿµÿù¼–ÐÍþWbOôzê²<zI”boƒî+E~ØF¨?
+íBz‘ÏwÚNÄ„žÈg;iÏþØïp=ýêuÂùEÝ ÿŸ¯næµo“ìïxÖy4qMzú©¹G5§Íòäk7w^»ª:ïy/üíûlKùu“–oë¼º^û»8î¿Ö‰û4Åþš_Wœ7èÒŠSˆ{â•è¿D¶<Åq€ã‘:“oÑ¢µ,âƒŠ{ËCÖÒŠxLâØÈñ-ÁzµŸÑT¶»Z	û¦Ù~~¨’ZwÝ¬ÖA[D&4U«<»–Ïi{Ê§®M¦â6ÕœªçGÛíô”¶¹1+·Þ†òØnŸÏèÎ•®½&÷¸g×µîJ¢³”^­‘ŸóÕ{¼?9W_xíýBHyx |<æ«¸ÑÁèïÁŸE°£¼	Þ¿å˜q=œPôøÀ	uÁqÐþˆ{Ø‹ÐOƒ­ÐÀßÐÎÐÆ3yÞÎˆ~ þkgt<þ>ïá^:°»¬5xOËrPï4E'"°”*}r=NDOŠMà hcs=œé²ìsJ£Ó@9Ø¶€ãàµø¼»ó¨çcüŽÒR®Ïº÷»7¼Ž7¸.ÿ·q_×w²âí®üFËÀøTþ tëRy´€w1~Ø÷ÁI®Ó¸fCþHi©Äuu¿_gh'E´„Å§²—ã,–Ù c6#–®·.î£;ùŠz¾¶Ÿ¥UgÅ;å.{€< ^“WÅ9A\ ÛÕ³	ºÆ`Í®ê
+
+sá\òÔY°\°ÆGwªšmUŸ„ñµÿï»5ˆè‡³ï~?¬ûøX÷œþn,›kþ>¾-ÆÐ4õœï¡§†zñÿø{ÎÊåï;û(ìF}Ô7Ð7× .ÊÇ$y‘ýQ~àÎTZÝ-r õSÒuÁ— y?HAŠý~cèVE»ŒÈ7Txh‰!B¦y(‹áe0ƒÁ`0ƒÁ`0ƒÁ`0ƒÁ`0ƒÁ`0ƒÁ`0R`Ý4ž>¦4›|…_"›ì5äW×½éY}Ÿh$ˆµ}ô5\ÅÚíIºíG{¦nh0=†7-ÑWó©L·-º>Òm›úX½uÛG·Y_×mv–nûÑ^ªÛÊ²*&çå®É}ô±‚ÿ±Fv+mQ?­Ÿ1Jn”@ã@[PV71¨hn‚6ÚˆñBA7É¸D7Ždw#^Tõ^ú}‚†½Écø(>BüŸMYJñÂæ7ÿ9çügæìŠLziE””²l)¶¯j†Ø°mQá”#*Ò‘­¶¬ùrñhëP¯¨ªrÕâgßêkÑp„)Ü–Y—M³u)ÔùßúJŠ®é–ZÔ ½ºè8CiZ¢¨²
+q›$vÛtE52 6±±VB—ì$V‰³Ú`•y*S‘Žh‹IG^QÓÅ\¤ÐË>‹<œhÂû6Ï{Výˆr/&¦‹×˜èCR3xÙ%bŠÎÿû.þk0z¨}et¢z·ûZ4¢kþ„v'²éùdœFtêjÍãBæ#d7rgí¯j }V^ÔàÏún6PJÙ¾¥;ôëæ$û‰Õpè9Ø\þ2Íjt=õ91Åj,¬Ï‹þ~°¾-ðÅ~,6Œ‡‰Â÷ÆLÞïÄ5Çßk®ÿƒq×<?—@ì”qÏH%Øc(Æ#ã£Ç˜Mô;<vxþd6•ä-«gÆlÅ§ŒGÆ£ÇÈq]J°ƒ‘›Óœ ãÕÞË
+endstreamendobj39 0 obj<</Ascent 952/CapHeight 674/CharSet(/T/g/h/i/n)/Descent -250/Flags 32/FontBBox[-157 -250 1126 952]/FontFamily(Myriad Pro)/FontFile3 42 0 R/FontName/EOUCVQ+MyriadPro-Regular/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 88/Type/FontDescriptor/XHeight 484>>endobj42 0 obj<</Filter/FlateDecode/Length 747/Subtype/Type1C>>stream
+H‰|]HSqÆÏqÛYåZäš”‹³?Y‘ÍoüBÁ¤PI´Ö"-Í£;êÜÜæ9›Î˜Ýø‘_QÐ)-RŒ¨EFNÛ°ÄˆÖ‚JhˆIQ'Hbvõ?zvÑ9«‹®ºyxŸ÷å}~//ŠH#E÷/6ä=u¤¨…2ÆÊvô4Yë´”8Ä9Êí•rûj>‘ØÚÚ:)ƒ]pa÷Ô&…D èê<›]X­­s€ÄŒŒ¤8QSÂš’Âšr¶*è[hÙ@ƒkµ²Û(ÂAu ×báP$MRMbóÏAÀDÒä¨#)@ÃZ“°O‘Fà #Ù@Pf`'ÿØšÿ €É
+„,`°šD§wMVc¼bSªmN«ƒ2‘´.þ„þL‹éÀHÖ Š¤"H~RŒ ˜ð9¤©C84µ£þØÞ.8ƒ
+zpFÒ+åº7KBÝàj>^—ÁuŒüK5Mèš<„U„k˜ÃãfÕbÅ‹N	Fš¸à2
++Y	¬Œf¹ ¬ZuåBSVðä"<07;š£ž~‡÷¾©Ö¸DÎ¥V»ŽÉz0oS¹/MÃK€ŽOçc¾‚Š³Oü÷µýŒW\H,.½s×Œ;óes­Í»…[¾iíôÔè”ÄÀÇrÕÚ›þ‰þq<÷¨Ý=—:Ý¸ÞUf2hâÎ¯þÔª‚PúöÃ—¹gÄ¹a|°½¯Í£,NÍ\‚æft‰…¬d)š…~ìvßÍ«þ|Øï}­ùü  [Ë{X8)‡Y±ÞÂzËew#nw;­Ô¶ø*S
+®æ_zÑÃ¬j¦Fs®äK®Úðm¦©ÍÚÒ0J{ÆGÇ^ÑzšÆêñ¿\áa¬jEäú°¡þ¡Áø‹!ÿd@à
+ÜG,œ’ÃÌXo~–¾¢œÆ{0•¿ó“,¨î«*Q¶3œ‹:†aÆŒ¯aV9>RuQ±½W9¿ƒd;aÛnCý[€ Xld
+endstreamendobj33 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj32 0 obj<</LastModified(D:20191029144906-07'00')/Private 43 0 R>>endobj43 0 obj<</AIMetaData 44 0 R/AIPrivateData1 45 0 R/AIPrivateData2 46 0 R/ContainerVersion 11/CreatorVersion 23/NumBlock 2/RoundtripStreamType 1/RoundtripVersion 17>>endobj44 0 obj<</Length 1199>>stream
+%!PS-Adobe-3.0 
+%%Creator: Adobe Illustrator(R) 17.0
+%%AI8_CreatorVersion: 23.0.3
+%%For: (Chris Holdgraf) ()
+%%Title: (logo-generator.ai)
+%%CreationDate: 10/29/2019 2:49 PM
+%%Canvassize: 16383
+%%BoundingBox: -6 -19 327 173
+%%HiResBoundingBox: -5.61783439490409 -18.29296875 326.101910828025 172.70849609375
+%%DocumentProcessColors: Cyan Magenta Yellow Black
+%AI5_FileFormat 13.0
+%AI12_BuildNumber: 585
+%AI3_ColorUsage: Color
+%AI7_ImageSettings: 0
+%%RGBProcessColor: 0 0 0 ([Registration])
+%AI3_Cropmarks: 0 -18.2938824691501 297.496815286626 51
+%AI3_TemplateBox: 94.5 25.5 94.5 25.5
+%AI3_TileBox: -238.851592738157 -281.246941616044 536.348383229251 313.953034351363
+%AI3_DocumentPreview: None
+%AI5_ArtSize: 14400 14400
+%AI5_RulerUnits: 2
+%AI9_ColorModel: 1
+%AI5_ArtFlags: 0 0 0 1 0 0 1 0 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI9_OpenToView: -90 236 3.27083333333333 1491 1378 18 0 0 -3778 -732 0 0 0 1 1 0 1 1 0 1
+%AI5_OpenViewLayers: 7
+%%PageOrigin:-211 -371
+%AI7_GridSettings: 72 8 72 8 1 0 0.800000011920929 0.800000011920929 0.800000011920929 0.899999976158142 0.899999976158142 0.899999976158142
+%AI9_Flatten: 1
+%AI12_CMSettings: 00.MS
+%%EndComments
+
+endstreamendobj45 0 obj<</Length 5721>>stream
+%%BoundingBox: -6 -19 327 173
+%%HiResBoundingBox: -5.61783439490409 -18.29296875 326.101910828025 172.70849609375
+%AI7_Thumbnail: 128 76 8
+%%BeginData: 5539 Hex Bytes
+%0000330000660000990000CC0033000033330033660033990033CC0033FF
+%0066000066330066660066990066CC0066FF009900009933009966009999
+%0099CC0099FF00CC0000CC3300CC6600CC9900CCCC00CCFF00FF3300FF66
+%00FF9900FFCC3300003300333300663300993300CC3300FF333300333333
+%3333663333993333CC3333FF3366003366333366663366993366CC3366FF
+%3399003399333399663399993399CC3399FF33CC0033CC3333CC6633CC99
+%33CCCC33CCFF33FF0033FF3333FF6633FF9933FFCC33FFFF660000660033
+%6600666600996600CC6600FF6633006633336633666633996633CC6633FF
+%6666006666336666666666996666CC6666FF669900669933669966669999
+%6699CC6699FF66CC0066CC3366CC6666CC9966CCCC66CCFF66FF0066FF33
+%66FF6666FF9966FFCC66FFFF9900009900339900669900999900CC9900FF
+%9933009933339933669933999933CC9933FF996600996633996666996699
+%9966CC9966FF9999009999339999669999999999CC9999FF99CC0099CC33
+%99CC6699CC9999CCCC99CCFF99FF0099FF3399FF6699FF9999FFCC99FFFF
+%CC0000CC0033CC0066CC0099CC00CCCC00FFCC3300CC3333CC3366CC3399
+%CC33CCCC33FFCC6600CC6633CC6666CC6699CC66CCCC66FFCC9900CC9933
+%CC9966CC9999CC99CCCC99FFCCCC00CCCC33CCCC66CCCC99CCCCCCCCCCFF
+%CCFF00CCFF33CCFF66CCFF99CCFFCCCCFFFFFF0033FF0066FF0099FF00CC
+%FF3300FF3333FF3366FF3399FF33CCFF33FFFF6600FF6633FF6666FF6699
+%FF66CCFF66FFFF9900FF9933FF9966FF9999FF99CCFF99FFFFCC00FFCC33
+%FFCC66FFCC99FFCCCCFFCCFFFFFF33FFFF66FFFF99FFFFCC110000001100
+%000011111111220000002200000022222222440000004400000044444444
+%550000005500000055555555770000007700000077777777880000008800
+%000088888888AA000000AA000000AAAAAAAABB000000BB000000BBBBBBBB
+%DD000000DD000000DDDDDDDDEE000000EE000000EEEEEEEE0000000000FF
+%00FF0000FFFFFF0000FF00FFFFFF00FFFFFF
+%524C45FDFCFFFD86FFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8
+%FDFCFFFDF1FFA8FFFFFFA8FFFFFFA8FD07FFA8FFFFFFA8FFFFFFA8FFFFFF
+%A8FD07FFA8FFFFFFA8FFFFFFA8FFFFFFA8FD0BFFA8FFFFFFA8FD07FFA8FF
+%FFFFA8FFFFFFA8FDFCFFFDFCFFFDFCFFFDCFFFA8FD2FFFA8FD17FFA8FFFF
+%FFA8FD07FFA8FDFCFFFD99FFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FF
+%FFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFFA8FFFFFF
+%A8FFFFFFA8FFFFFFA8FDFCFFFDCDFFA8FD17FFA8FD0BFFA8FD07FFA8FD13
+%FFA8FD0BFFA8FD07FFA8FDC7FFA8FDFCFFFD31FFA8FDFCFFFDB5FFA8FFFF
+%FFA8FFFFFFA8FFFFFFA8FFFFFFA8FD07FFA8FFFFFFA8FD07FFA8FFFFFFA8
+%FFFFFFA8FFFFFFA8FDFCFFFDD9FFA8FD07FFA8FFFFFFA8FD07FFA8FFFFFF
+%A8FFFFFFA8FFFFFFA8FD0FFFA8FD07FFA8FD07FFA8FFFFFFA8FFFFFFA8FF
+%FFFFA8FDFCFFFDFCFFFDFCFFFDFCFFFDFCFFFDFCFFFD53FFA87DFD78FFCA
+%FFCAFFFFFF7D527DFD3BFFFD09A8FF52A8FD08FFA8FD21FFA87DFFFFCFC2
+%C1BBC1C1C9CAAF7DFD3CFF5227522752275227A8FF277DFD07FF5252FD21
+%FF7D7DFFC298BA98BA98BA98BBC3FD29FF7D52A8FD11FFA8FFA87D27A8A8
+%FFA8FF277DFD07FF7D7DFD23FFC2BAC2C2C9C9CAC3C2BBBAC9FD28FFA827
+%FD15FF7D52FD05FF527DFD2BFFC999CACFFD07FFA0C1C9FD07FF52A8FFFF
+%7D7DFFFFFFA852FFFFA87DFF7D5252A8FFFFA87DA8FFFFFFA87DA8A85227
+%527DA8FFFFA8525252FFFFFFA87DA87D52FD04FF7D27FD05FF27A8FF7D52
+%FD04FFA87DFFFFA87DFF7D7D7DFD05FF7D7D52A8A87DFD0FFFC2FD0BFFCA
+%C9FD06FFA8277DFFFF5252FFFFFF7D27A8FFA85252527D52277DFFA8277D
+%FFFFFF5227FF7D52277D52FFFF7D277D7D5252FFFFA82752277DFD04FF7D
+%52FD05FF52527D525227A8FFFF7D27FFFF7DFD0652FFFFFF7D52527D527D
+%27FD0EFFCAFD0DFFCAFD06FFA8277DFFFF2752FFFFFF7D27A8FFA82752A8
+%FFFF7D27A8FF5227FFFFA8277DFFFF7D27A8FFFFFF277DFFFFA8277DFFA8
+%2727FD06FF7D27FD05FF2752A8FFA85252FFFF7D27FFFF7DF87DFFFF7D27
+%A8FF7D27A8FFFFFF2752A8FD22FFA8527DFFFF5252FFFFFF7D52A8FFA827
+%7DFFFFFFA8527DFF7D27A8FF7D52A8FFFFA827FFFFFF7D52A8FFA8FF277D
+%FFA827A8FD06FF7D52FD05FF527DFFFFFF7D52FFFF7D52FFFF7D52FD04FF
+%27A8FF5252FD04FF7D27FD24FF277DFFFF277DFFFFFF7D27FFFFA827A8FD
+%04FF277DFFFF277DFF5252FFFFFF7D27A8FFFF7D27522752275252FFA827
+%7DFD06FF7D27FD05FF277DFFFFFF7D27FFFF7D27FFFF7D27FFFFFFA8527D
+%FF277DFD04FF7D27A8FD22FFA8277DFFFF5252FFFFFF7D52A8FFA852A8FD
+%04FF277DFFFF7D27FF27A8FFFFFF7D27FFFFFF7D52A8FFA8FD04FFA827A8
+%FD06FF7D52FD05FF527DFFFFFF7D52FFFF7D52FFFF7D52FD04FF27A8FF52
+%7DFD04FFA827FD24FF277DFFFF5252FFFFFF5227FFFFA8277DFFFFFFA827
+%A8FFFFA8525252A8FFFFFF7D27A8FFFFA827A8FD06FFA8277DFD06FF7D27
+%FD05FF277DFFFFFF7D27FFFF7D27FFFF7D27FFFFFFA8277DFF5252FD04FF
+%5252A8FD0EFFCFFD13FFA8527DFFFF7D277DA87D2752A8FFA852277DA8A8
+%277DFD04FF52277DFD04FFA8277DA8FFFF5227A8A8FF7DFFFFA827A8FD06
+%FF7D52FD05FF527DFFFFFF7D52FFFF7D52FFFF7D52FD04FF27A8FFA8277D
+%A8FF7D5252FD0EFFCAC2C9FD0AFFC9C2FD07FF277DFFFFFF52272752A827
+%FFFFA8277D5252277DA8FD04FF7D27A8FD05FF522752A8FFA87D27522752
+%A8FFA8527DFD06FF7D27FD05FF277DFFFFFF7D27FFFF7D27FFFF7D27FD04
+%FF277DFFFFA82752527D7D52FD0FFFC9C1C2CFCFFD05FFC9C2BAFD07FFA8
+%527DFD05FFA8FD05FFA827A8FFA8FD07FF5252FD08FFA8FD05FFA8FD05FF
+%A8FD21FFA8FD05FFA8FFFF7D27FD10FFA1BA98C199C2A0C199BA98CAFD07
+%FF7D27A8FD0BFFA827A8FD08FF5227A8FD39FFA8FD05FF277DFD11FFCAC1
+%BABBBABABAC1C2FD07FFA852277DFD0CFFA8277DFD07FF52277DFD3BFF52
+%7D7D7D5252FD10FFA87DFFFFCAA0C2C2C3C9FD09FF52A8FD0EFF7DA8FD07
+%FF7D7DFD3BFFA8A8525252A8FD11FF7D7D7DFD41FFA8FD1CFFA8A8FFFFFF
+%7DFD18FFA8A252A8FD41FF7DA8FD19FF7DFF7DA8FFFFFFA8A8FD5CFF7DFF
+%FFA87DA8FFA87D7DA8FFA87D7DA8FFA87DA8FFFF7DA8FFFF7D52A8A87DA8
+%7DFFA8FFA8A87DA8FFA87DA87DFD53FF7DA87DA8FF7DA852A8A87DA87DA8
+%A852FF7DFFA8A87D7DFFFFFFA87DFF7D7DFF7DA87DA87D7DFF52FF52FFA8
+%7DFD53FF7DA87DFFFFA87DA8FFFF7DA87DFFFFFD067DA8A8FFFFFFA87DFF
+%A8A8FF7DA87DFF7DFFFFA87DA8FFFF7DFD53FF7DA87DFFFF7D7D7DFFFF7D
+%A87DFFFF7DA87DFFFFFF7DA8FFFFFFA87DFF7DA8FF7DA8A8A87DA8FF7DA8
+%7DFFFF7DA8FD52FF7DFF7DA8A87DA87DFFFF7DFF7DA8A87DFF7DFD05A8FF
+%FFFFA87DFFA8A8FF7DA87DFF7DFFFF7DA87DA8A852FD53FFA8A8FF7D7DA8
+%FFA8FFFFA8FFFF7DA87DFFA8A87DFFA8FD05FFA8A8A8FFFFA8A8FFA8A8A8
+%FFA8FFA8A87D7DA8FD5EFFA8FFA8A8FD19FFA8A8A87DFD60FF7D7DA8FD19
+%FFA87D7DFD0CFFFF
+%%EndData
+
+endstreamendobj46 0 obj<</Length 31839>>stream
+%AI12_CompressedDataxœì}gw*¹²èû<kñÀLèDv$ƒmœn m°In`Ïìûáýö§’:ÓØçÍ½ëÎœãZ­’J¥RU©Âvà²ÍuÇm!ÊÅh¿ï¯íí‚(ð³±˜õãŸýµÁ`>‰ðSð:ägR1Zåjé–ÔòN§ýñ(ëgQ1ž–áý`¡'ö§þêxÐýù?‚g7ýÙ@@OãÏqôS	¸ïß)ÐQoE~†14Åf(–f2~6Ïø/Ïq~ô‹ŸNûÿ-’\ƒÌç£nô™ÿ“õG“þ(z‡cShÀøqµ-Lõm±$“Jsq.ÏÐq:ƒ^IÇØ›I¦S	ôn2Æ ÀfÓ4›@±±Žg’t†K% Óâ¸3
+£Ù¥8îÓia<‹Ó¬¿ð›ùÏy4·ïƒñßþü€ï|kß)G3Ôöü·Øç»¨ƒèµð9ð"´	û¯Çíñl­÷?{3í[‚ÐºžÞÍÕ­r  5ò3?ÃáÌÕ¶•Ÿ÷Ý‹ù°- åJ¤øw®…çq;E@sÏø÷T«6D?5…Ù¡Çtp]Ékg~ÅÿŸÑú˜nÐb¾†äžÅñdÈ‹ßð¶„n.fãÉ“ ?›IÅ~ÓL‚M'“lÒŸ`¤o„ád€H¯\&KøÙú£|’›¡y’Åe¹t,`6Å¡þRè—4Hq&É$éxÜŸà’1.žFôÃ¢UO0~á&“àhD	†KrR§ê*¿úÂßYÿÅx$HˆÍ‰³&¡Ãxœ¦É_éÑõ| ˆ·£>¬‹ËÌž»Â ½¡vQð¡ø_Fý+µ¸áÅOa†èw<˜ÏðNK+PÐêÕùß#iL„ÑÍø5š¡Ñ¶Lú¹‹h—SþA#Í0ˆRi?“Æ £\
+}‰¦8V£þ• A×Ð±2$p‰¨¢!ö?û£l”eè‰‘(¦"ö»*Á¤XšüÁ³‹¡YÀ?“ai´íÜþ’Áÿ¤’L"ÍÄY7¿HˆAhžÍ„‘Œ)´
+çr¦cçM˜OiÔ-Œ‡°âSÌX!#~%=U¿àg¨‹ùÄ÷×³ï/.CýÌÇ3aŠzþL’BŒï—àgØ4Uš‹c„pZÓ¢ÍOêQDD~í¶Éoˆeô'Ó>OuùÏOA”þƒžS¾ˆÈñc üCMqÖÏ§ü¨K5;¼8QŸhGã¾ÂÇŒj”Ð:'Hßðê5( qSùyÔž£_g”0êòÓ%ñfˆYÚÒ]ö0êlj J^TwŒx<âÐ~´©Çn_ÑŒ§~j:á;É8Õ™‹¢0êüF_’T[£600&™¦äöTg<ù-õ)v?„aÔ	Àˆ)„ÿ~‡ŒÆ3ª÷{ÒF”ˆùz±Kù¡-5Açzs>¥f§s„´þX¤f=Q”o|g>¨ámŽÂ¿u;hýqo¡ÛxÔÚöÊh@C~Ú™ðˆÒixø3çEô|ìñƒCúqêGLå0= ®rbN³š9‚ßœ2ûL€Ê•¨‚4ª„_§JøeÔKIózIy¯FZÕˆš¦MMiSšõ¨uÓ /4ÈÍ2¦†òÞp>˜õ'ƒßTc: š¸•'tK^¾Õ¼|«¼õHÞôÆ"¢C#DjSŠ'€yy>¼æmž€æ•NxŒ^ :2:òº@zÔ—QW‚ò^Ÿ´ê“V}ˆ¾ÒF@è€cÒ|,i¬ya,5QÞëöõá‚Œ9yuN Íuã™+ïü&g¿åŸ}Ý”“Mœ¶n¦èÀÑœ3\3šÒ¨3ñ%ëo-ýfÂÀ3µØŽZ|“0û›'†„ø›‡H€7¿'‚‡‘i¥ƒ(‚Æ£ýÒ5%‡ŽÙ(nÄ¹f`àÄïñ‹	~–n]æèaEÏ'µÑÇØ÷W±wBÉ˜è îúí/ô	£XšA#¢}¢ïJ$ŠNB¢£Düä)z•ÿëæý¢ðÄ1µòkiôKŒ'šŽI;7=^øZLü@é°ÞG§Ï%ð¤v	…Ùƒ«>ßš ´à^pCÿ64Ü€ª5tCÜóï±ø¦j"1áÁ©Çæ·0ëôŒ}J¿.Ýë%?ë!aŒSä«ŠaÀ:ùÍÍÌ<:íç˜ôú^œO{þ›ñx ônò\¤}†Á›n€6ÛãA:TÀh¹DèéwBó7:QÝQHVâ¨1"øYœ…ÔÀ8$ü’w<þ?MyËzøß	
+3f0ô8ÒÏÿB(ò"#Ém^eÛ¦ù7˜A½ßvØ¨€æþ¨‹ÆÝœ÷g‚º7ÇÃ	ØüÍ?ðÎ‘[6Õ.pœiO¬hÔÅYFô<rf)'¸;GüÉRþ†ˆ …œúm™…þÎ[\|L…ü1i@ ùè†ó¦fÅQ«Â3¤¥²ø ƒÓ´_óïúÇŸ!Ï@õŸýFj’îÎFã¿Gø›?sQSüPðGÐãf8AÜT~NûèO,™`ã,h© Ú‚f›H¥R,“JÅ©4IÀ/Éd"Á²ðc‚NÀ/\"3	&Js‰$¼ÅÑ‰tšål&Î v®~yàaŒ„£‡ßðí}úB¿ý0è?÷?¿Òþ®=¼&Mºh"D”Ø÷ýå§dÌ¦ŽV‚vž>Í ™¥4Ç¥¹d&‰FIÓéx‚‹#µ=É1q“ÐOès<¥ÎÆÕ/n¶Ïèw©D¯ŽÓÕUi@ *–B³c™xý7žIÂ
+'S&gSL"§ãø=KÆÙD:CÖ<C#½>Ådh°S1ÊÌržæÉXÏS9ÚwÞ,—ü@˜ÎÐ/ÛëžÑ¤ˆ±ùð_°
+F[ãeý?¯ŽY™·]Gêy1¤É’Œ„¡ÉC"zAWÿGþufüÕ
+‚4hÙJYägˆº¶[”üÐ |íw =¼ø[úáá¼~1î
+÷ýÁ†ƒjEG¨Øo#I¼Ü8'Šü´›5AÑ´ëô*/
+#©ë§jUÊcø3ûG:~ÜM[¿xqº6zs–}Û_ü`®4†S‹†#Ä%¤vÒh¦ú¯ÿíQ… Á–ãÎ·Ðu…&¹iä_1Áv_"1n&‰h¦)Ì.ðl\LTÛ|D±:R{¤¸CEŸoW;ÃÍJÿ'ïL!ûË=[€¶ÿ‚‡yvæÓÙxø/`”D³Sd78CÑ>tO©ÿ‰}ƒôoÏÿ¬­<ýøû_@ßÿ8ùtÐïüÏaã‹~ ÔµÀìÀÝâÿKØ·Î«Åij¿]Mí÷¿djL†‰ÑHYL"M’s1»ž WM®¦(7ýWÌ“ã˜Ò‡Sq°„ÓDÿîwg=Wó”Zþ+¦‰8S~<¶›W{<CRH]ø˜‡WS\|é_#p`NÚÏÅŽ€}Óþ:ÿã
+3¾‹D±5&³ò`6»’=ÅÍiZëI;Wcÿ¥(Lñ—à¿þ™á»	¾Ýôg2_ÅNÒˆs5ÙCÜÁÝLÓó¹ÐíÏ‡~Õ5‘·£~H$†¨ƒ°³’_ò„D2”™_£r2	Zæ/¹ZÆ.L{þk\kúÿ…-lp2¢u¯4æ³É|æô­Lpq|u~ô9‡ëùËñnjt/€aNø¾\6¡ŒœKÁ~mšgí1/v›Â@èÌ£‚IÉê§ÁLšÎ¤üi&™$“½÷G3L=Aìë§ã.ò`‹ýédÀÿ>çá²™¬šÀÏ,.–vd”^æ®eþiô\t¡TGv-nÆ×dPd”—ãið‚³Ê@Þb6œ<Œéi2‘àÊòfà¶Ì¸þ~Æ/ªÖãZÑòJðƒþÔ¸:ÓÉx¦"˜ü6ä§2jãLF”I3)£qÂwe )ù êNú1uÓæjþÜ|6VW^	V3•™È¦žø®}Šý®ª6d,çl4´˜ð´§ýá|ÀköÜ
+¥­‘ÇúÛ*W¢ulEæ9þïÑ¸ó=F[ð“\tº[”OQFö÷Ñæg‚€m`n»ÖÙqzÚa86V	)×Eð_þ aÔÍ»JüVóã‹õ«]ò"Úwà¥wßëwz—âø£?Î„ß†Í¬kZ¶…îBS…TumážX‡ÈñÈ¶Ýe±M9èÎíj$ý
+óæG³¾í~jÒÖ4D´€§3ð´tÛz†N'»	Æ«ÀŒV«Zq9È¤3¶­ï5BgDh"Œ”çƒ|$Háè©¼¥ÙT2%­ˆÆË|[×0ŒŠž­æU²Ô’°iÛk…ÒÔóÑ´acÂwÔ¥‹'l—ùŽgaÇæ ¿.´N[¨a?3~ÔQN0Ð˜þt<ÿ1žbÆ>š3^aü
+Ù2Î¯uøà€~ð‹—Ñ™–7,Í2	{t•þ™©2•Ëqº÷â‰t*n1®ò`<µôcGl¸±††Ûº¡!ÜPOCl’e¬³ÓŽ7‘Î¤›¶’·iéf°X©ÒÕa^SA¡%Ë%+ƒAéCrKÎ²Wh©‘ˆYë¡VÁ·s<Ò1*Öbú7”ÖÈ©Z&)b!!ú{úÛü@³ÍÆÚô'èèó?~pXDÃ+YUÿÄ	ÜüNµ##sÕ!Íyá‡]ÃþUÏ&3^¹6F¨Ò?“±8ãnnŠú˜ª¯¦RƒDOU‘F\Jâ$N¼ äŽõ§=ÄŒ´ŒÄ'‚n°ßjëò&¥2Þ:ºO´½Xñ)¥ý]*ÉÀØ&ö%ÞÓèµQWø§Ü§ÊDãš¡C§Òþ4Ç$]L3N<Ø,:NèvM¡3)Âs&¡B:ÃrnÇ¡ raédJ™æä.‰ÏlÔ¥bhUòR{rI_êV„MÈûÜ® *Ä/Ó)Fö¡ÎXì
+]fà§.Æ3ýs€aýH9ªˆ¦Áº’]ÀÖ@ÞÂ^ÜàÀ
+oaƒÇÂ[zXŒ¿tÙôŒ¼æš´uÄÁeíµV4ÊÄRMoüwµßu°½hŒ.xòv†½TÊ'ˆó9çUÕŠÑjŒ£±zøû#|”€vnvî`ðI’oêä~UM•Ö0ž-Î³#/ÚÚ‘t*$c:ÚjÐ7ªú‘J‡LttŠmøóºã—¶„¬éRƒuá|]è¥ ÇwA:¾¯uÇ·ãn’ Qª©™ú·c"?ÈŠ­q‰¬ÚØŠ±Ùô»?i#”|;´4ë©0Æ^ÂöM‘Æ=Pù’J#¿c~ô©l”E#—ñyòÚ×öS)Ðúé¸®Ø~À²	IàtKI¼–f{Íi­PÓîÏ†<jNÂœ´í'ŸÃï°„îøã#F®&lÖ\ß|>¼–‡¯2¡$-à8ë fsèc²˜9žõJ0_c´LÓñ±7êr8îº¤Ü%?5{sqR¸•,O§6óÁ-…È±]§fóQÇ“9]ÛÃ?“ØHÇÏ` ãIwnÐ7-¦ó	¶ýÝC¬|l4w/t7u V!^OÙ–}uÆ6‹ˆZ€Æbß’™Í9«yCb‚Òüf?vSÂŒÊÄnl"™§íè{ Æ”s³‰Üó&Íúš­žÂ“ÛÒõõÎï EŽõÆZØºöZVçen3\àÐf`úSxaÐÓÙ Ö%]â±+;Þðžô‚-n^štFîÇ5éºïžp#õ3 ¤ê¸Vf¬Ó€|S¦ŒÚHãTt"ËÎtŽIš‹%@…N$Ò‰—¶z©±©1Qóf:Æa+É¤Í¦ìß„þ¥^œ)ìBO‘ÈÔõ·û‹"’‚Eû…€>4ë›J{™©ñˆ²Ú=Z\ÚlÝ&ÞÆš1ÿ½ÐF¢`ºþ—`ó¾qùòÿb6œ‹Ø¾oÇ\ "¾r ðÎqêv…iÿsÄ;05UœùÃÊìw2žÙšjNîkÚñÝ±Ú™Ó(¡å:Czcñ¿l×÷øûå¦‘²7iËfS°A»oøËa
+3¤˜Û¦¤«É óÛ†oFÑÔž„a–h©üD™€)G!ÏYÊÁÍ¦«âè/wœwLXª†¨Ý¼„HwI äÅØ„¥‹ø,hnZ–l9ËŽh+<á6 žô‘*áÔËÜNDMÜ‘ãààÆ²Í‹¶2‚^Ü×pq­gÚÉ;5Ö-.TÍH\´VGb¶>F³Xw á1.zõ|ß¢Ï‰ø1VõwÎl%¦h*¿„ÍðP“vT@pÓy{j7$ÔOgáÖ×²!:Fvçj4>yÃ‹E«ÓÁÈö­Ðéš”FâÌY$´íñ]ÈQb§›MˆffìÏL²$û”™hZ.Ü©Ø)®áoYª7“ÓQK[µöP­}!'·ÔZ¬i6öy²Í»Jñ¦h2ú®cêãob†DO/E¡Ó×“	Œž=(';«¾€}ˆÁÃ–æKÛ™œFÍ°EÐÍ¨yKLJÄbDîï)	°ËÏ“WÀÃæ)Füä¾‡’óñ/¬5>q
+.§vˆÖ{&¦Ä&ÿK8'ÉŠ„œÁ¸ædç	>k’‚øWP¾‚7=D~H3ë	~IgðO¥œcþ¿{ÂÈ?åa~~¤Mµè‡#ÕÏOág)“A±¬øáÄü·SÜ%ú«ïì÷xîG+<òG~¡Û‡'4éî“ïÀn¬ñ#`Ê«#t<øgcè¢#øûØÈÌûüop&â'“AŸ°
+±øhxµQK«j7Úqˆ9ÝøCßŸúç£o ŽÙãöšnuÝû‡ÓUn}#¢jú,[6gü¨‹èÁ¾)M«°}Û8®dšsÑ-nWïkí³‹LU×8ï¨!éšßØº¶×NJ•~Ô:¡Är†°f/gÉMqRÄ¼N2²l‹¸.¸Rºiz#ö‡Ú¶vë!ûg!Ná¢ç2b¼HŸÔF¼aÑc’(¶°ˆË1ÚLÊõºÙèÁáÀü´•Ç{>;=q<Šhó‘7Ë[1ÓÅ”Yß(æRà'Äu¹¯€Œ)fÿ÷…kK’¡…ñ¨‹µ.Blÿ£ïÖŠeÑÍ2//,ª·NC8ä]XìLÞÐÑÝ;x{°ö?õòž4­Ú¨ƒÝå‹:jÉ!}¬ÍÏH®Pûmåà}hÍ•‡£Ù‹¶>”.€Ùùñ$,X¨gOzãëî¼ê½_b(\Lüð]î…ýÍ†áµ_´Öêbùžê¦„½”ìtAå0Æf½2bd9’¾M=å¼½wí¤ýZ¾©;†½½ª=8-,Æ£ë^pÐ{Õ-‡­òðŽF†»:4¾Ég}ÅË'nz3£}[=Kp&Å\{üË…YF¸l"iórEäCŽçæ¢Ï½UsÍô®æ¼Æ©Ú	Ž9^XÖâ¨VÞ³Ã‹-Rõ/{: õ¯ºF'><àS:J–@¨ñM×Å/.RÃÛžpjxW3bÛ• 	í…›Þ|ØñýÃQ„Z¤Íá|£53›Ù¯´òª1H`ßDï.(Ú¨¥ú^Ú:›¶ª¡ƒ¾	Ügk6·/î=3é Wci5œë²ÿ0¸ÄaÑ¬²àa5RLû&Z¹&-•!×`…$A{„ü²,£ÚŸ@ÛÏ5µZ:Qà<Ä=‡ï©ðñ]›¢©ðy4|Ü›qð‰\e9åÁ•ò	?ØçŽofùâG¦ò]Ý¼>ä‹ôã‘ò”^'{ÐûG:®üT˜@4Ç=¶¦ˆ°åJ :iÆ¸z&>ªvâSnë
+ƒŽ7Þèêûé1,>Jîm1?/…Ïë÷Å³Z )?-~Ç¨i¢šy¿©–îóÂ5sBM?²¯—ç™âSñ¸·Ì¤cùÐp§Yx­Š¥ç÷0ÏìåR£D º’ zÌfwróˆô¾ªp'¶ˆ´ºÏ0¯f XFàë£4¹Ãñ7ÃoÊL¥ÐÍÓ­@!|ô-&™êÉÁ)]åŠ–#A`\!YãÈÝ[-MGÓ0œ&A<ú­#IBýïA 4Ë÷iêð1„Ñ,AG ið%Ðò’ÃX=ÊT·¾ð'i1ZBaxÝ-²»GEC´é
+{¼Y}C_+º»óX”'RŸŠâþôN|¤ÏšŠ7ƒÚE†~Ó•íîä*Do2xYêäÄ×ÂÞ	Bdz.Q	;=W¡ÆÇ×Í‘*#~_[½¦ÔÃ÷ÄÏÞ„6…ú–|º´‚ZÝ´©'²oL¦{xžnÞ=^šC½:Ü=ÊžOÍ †÷;ñTNnnÞ=]$Ì¡ÆŸèr>Ù0…ºQþJo¸ýK3¨tù£ÛÓbºÉÍ6þX²‚Ú¥+ñÑ|®åŸ[¶pÓÞF¯ÅÇ*£]ÚÝaV‚z¹»kXZN¼£z*"ËvIOPÏâkñc8´¸®ñW 3‹ÝFUÀZ¨“ê©%Ôä½¿iµ#¾¥™*€Ñ ¾(ímþ$ççfP§›“|Ù
+jõ˜1OæPã¡G ýÁí…ét7Ê|Â*]>»Ê[@Mnn'Ò‰c*€Ñ-m‹.onÌ¡V¶wêBïÖjå*}g9Wf'ˆIK[zù.ë6ÏFhº{™Ô½¨ÕÖPÞ²©‰j½vñ*A}ŒamôÓM%b±'s¨ñ§<]^¥Ì¡Ö6æéúc'm˜Mc TUÀ¨g±ŸIÄês˜nÖææPÏ¸·z¹|ÀP%­îM­_³„Ú<OÞ¼[A-Òwô[Æ*3Ý¨G7oº­½}S$ß½N-¡Þ…ÖÄ
+ê9}=Îc¨˜ÒÓ­—Â÷'i±`
+õ)róf	õkã¦ž7ƒŠÀ À/Iú•›#ùâ¶ÿÝ¾ˆ˜B}{{hYBÇÁOYœîË9ý^ªÍ¡–o™‡ÙUÍª(^D7%¨m.¤Bû'œÙ+qdºüÆ¬¢?y²âœ+Ð 5² µqüy+=œ ¨‡¢ñäÉŽ#*>o¾3{†]»ýñ¼ñ¡²ùG¦¦g×téâ¹P£Üøâ"*Ÿ<…™
+À`$—J_12Ýã`)¢ƒšèívÃ‡â¶²…3=_Â‡é‹g€J-BMno>VÙ À§Ãtl¾Ñ“ f¯b†¹~Kßêñm½®Ç0"©¯ÞŸwH½,Dv6°ÙQÛÐ@~:ß	pÝáÄüi<„6ÏQB°z*âµiŸ÷- ‘£tÐ(‘§'õÓ!]?áXütñ”y:¦ë×Çqüz±AŽ®wÏ’V¯èóÀ}Úêi‰ntj×†§*ÒâO-ºYøžY¼þ¡›w›«§1úæä<hõ
+cÑ·Ÿ˜yƒƒ -Î)éé"×ªÒw·CòÔ¸ÝâHŠ»ûŒ+H[lP§ï·29«×/èûd©`õô’~ÚL½žjöüE¿><íY¼þ’¢_¿>"VO3ôÛí>gõôÀ´’­ŒEƒ–ÈÄöÎOù “ygÏ-ž¶7™üÎ[Ùií&svµqjñzgÌ\|³}‹§Ýóøu¶c‰´ÄÛèfÿ`ödþ:;½ì†N± DšN°ªšÄª'Gä©‘²38ñÓ/óñÐKø€ý¼²zú>Ø^kž¢{×ªR|4	voÂùñôB‘¡'ÛX#Ê[éEÈ[*o¢xÌ Íx¶[(ß§‹OåÇ›âSé †~£Ë…|¬S(ä©³0z­9Á¯ÒªïÛG t	ô&·‹šž‰>t;<«L”:Ov‘žù0ÇÊâ³Šb»IõÛ!´7JHÊ^eqƒÝ=¼ŒÊúPã\ÃºµP½½íƒÀØjüñÁ Ñ Þ(w)K¨tù&e	Íþ9oõ¨QÓÝ¨D3¨ÝMª8Í†§
+TÎ€áøC¯¾/CÅ"‡ÉA-ÔxsK…*Îß™˜%TLsP“€4P-^TÀúé>[BE²–P±^¡BÅÇš0¨]+¨‚5ÔôÅÕƒ%T hS,‘rJË
+êÕÂºnf#|üI"÷¬	˜7ÝwÕ.þR7k'SôMC—¤)al=©·'évpyŽÔùÝç‚´øë<	Ÿ‘‘Ë)Ì½yÂDn™ˆòçYkìI/<‚>®5Ä£Ë1ŒÄüæ‰Ê£0³!œ&¶·ñXÕ{­T/Ah(Ã)‚vYÆMtC`€•ÛKôug[úÃ?uŠ‡dú’71jÿ\dJ¯ÓŠ†Ùi}TÚ–þDÎÇAD#0X,Ñ@NÓ¢Q‹ý<ÕŠÛðQæ1]S³1)MLÇ„÷M¤!$¬2fvMŒø¹âXÇ¤bÕõbàÐd’—çâ?×kˆäo…§Ù,ck¾'Ÿ¨Lf3++m½†i.–q?ì_º®ÔÙH½E\ôæŠæ+õD²Yš¾èfãÑi!ÔÒœ±oO­.vÌ _ô
+øÒs¡ØØÀ…0	<F&:
+
+<®H	&RÑt Œ¸€–…v¬ŒýW0œ™ýp0ŸÇ$ôÉW&&Û³ôr0ðq‡íIÔ"“É3guýöTæçarÑM¸¦…ËØf¡ƒ‰9¦+—Cçyíy™Óü[‰¦ß÷²ñ~ù)E&úƒ³d6•³ƒ,¯[ª"å7–ˆ!`ZÆ³[=¸iavKI¤4Ñ~LÑÜžšu`Üõ¦ß€ÌdAh³?–³.àa–Á\U³YÍÖ|	ç…=e½H|™}çÏìW•ü‘†O¬ß‹‚fˆJrÚbo‘|P–vlaºåËôG!öl1Íp3éÌnYâ?ËòíÙ.V£,‘´Ñ¼¦VB‚ƒ(©7w£ö#—5žT‹¼ˆÈn…á·v«záÖ¸Èn…ªïLÀ_@¾`åp1,6ÿ”95?=•áØŽI’ð°6-‡¥.Ÿ»5üÞ2¬¡V#ÀLwÓV#Ð®¡"ë¹XCÝe±¾hoÝ®Lä†Þ¾„»õÐ>`]É·¸Kôö±ûó°>¤9|‘ö‘>­	iîæi’L¶ÙÌŽ~Ú-›x3åGÒ±æErþ¬º×å3{§Uá‚§êBú¶”Ð”¾7Öµ=«psæV–(-d‰ nkÿ¬î	AÃAÜB/§-ƒ VÌ…"!Yï-gãÄ\„Ö¨QŽZåHø	V£œÃ®< ãÀ Œª{öÇüM-?Lfú#¾UÍã˜Œ6“jGÃùª!~À—ì)²Äˆ¾×éÈ…ùCe#š]¢sKÀÃRÅWZ³õ˜f›Nv·¬ æ–…˜\¬XÁWÍ=+°˜¡l`_gáÝ%o“™ô`8oŒÄk!é‹3f/ÿUv;CÆz{îw¦ê^#JáËÏšðeµÓVwø²‘u-(ïóÍ[ÜìÃSýf·PãmQ‹Æn+»±±¢Ñaxª7qW+¯:Ç1CÌ	NéX³çhrÌîÊ“Ã^ªw7çNè¶3„p[™Ú~^Š]ÀÎrŠÀÜW™!hDA†ƒÖ»‘è˜9ë¹;gy¬9á&áÍX©¨ýRç©¥yÇŠ)èLz1û8{9Ãb¶ÎÜÍßn»°?:‹Ù“3ƒÍlß8£ïø–Ù¶Žñ\$^C¦Gã™ñh4'‹çsqþÐú£q™}s|{²Ç5·N›xrf<=“;^›ìU@.7¥í¸;ë -+8[8þ<°,€pc8üLqã,ævô'Ÿ5A»swèÍ]Í¥.úT@¿Vò¥Ðå|hZÞn˜‘…jR5È÷•Ë¡á\Úä†º{Úš¬´¨7Ë-èCÃæa–4ãk×/\õ> ÷²gèEÇ¡½tö4í»¡£ÈZæÅ½íñ,4é-æNäpwÏ
+-J¢7.®'°Øõ¶ÂñcÔ=al6·Fæ7…–Øìî°”»µÑ^šÛq7¤Ú$Bî†~ËªjÔjâÅÃ­îFÜàlï‘À¹2wS÷ÐÛº¸ÛÝØÀÝ– À Í­ƒÀ½¾‘/yçª7…3¥9vu1 ãØ‘'q1âv½OYªÿTo>”iÉ\>Ð/ZØLÏV)M{I™Ê.’™´e@#Ú3úŒ¡ßLû2]ô æ‚i$6Ó[Ü‡»%ï„M»ŽëÆ_À…Ì½Éf]fãì}Pyœ¬¢q+k‹§÷™ZB^Ç½˜Iý*¥yéÈÙ«ÂÐË¢Í†td¥y{ŽÊØ-/‹íäucoÎv/ƒšíùÈoTÂÆó‘ß¨»Ðy6µwÒ–çã½'éßJ)-lmÒ?êÊäp4£47çãË'\g„Ô.-³áÆ>ãpˆðçë9ÖPGnN#çcu´²sRÄxœ;÷\Î‹±<±•ÃËùˆ-jçsa~8êU\ãù˜FÎÇlÐÍbG
+æyæÊËKuí°œ6È/$µcÓaSÝ™VWxH‘°Üäš»5·ûõæY¶6?´DWûÜÑdƒI;¤yR@ÑjÞYËŸ&nplúÁÖæíà®·` ÆÃ²6f¸Ød†cŠÍ?<F%'ÍIµà±´÷¨S¦^ª+g×¸†n`=Kó5Á¦™œ%ÉbÊ“×^èÍÕQcâÇoÒUrmÆ6ÿ¸±ãÊmq±`XPWž¾¤+kMº=5úbY‘…»1i­ÉZ¿N·N¶íöèAŽrË”ª¥E ù¢xÔèUw|«¸Ù—Ê™­“·òÍÑeÉS8Ÿ},ÑoÖÎ§%²ÅX>=³Y!œÏ>–ØÓÖÎgË§ßž+„óÙÇòù´¡‹«„óÙÇòùôqkË‡óÙÇòùô¡‹Ë‡óÙÇò!0ë	ç³o‡¹À:Âùìcùˆåvá|öØ÷žË†ó G¸©Íæ¹èÊ‰F#ðYG"ý5WÃ2“ƒs’€ßA‡¸-½AÊ³«¬æBò¹¨—Qe¥ _îý×¯‰Ü¢Jo2E•Š'Ÿ’3ÅU†ÃÑM§”ÙD¤a°óúóBUcKÕùzâs;CÕü –3º“t¤½#XñN†.û}ã¿ç"xO%ZIN³¢Û·’wƒ£AFcoÌ|ys1±ò/)Ù_ðiÄ.ÌÍo¥%ýKt\ ÍïesI7
+u$fþ%f—ÎawžýKÕ(»[ùÂ¦ä¤¸ÇÉ‚–"±RT 7»@1'GvðRÌÝGmvl,œÌîE›;SÜ†*¡1µ¬ý4%ÝÓmÜkÙ}8¥Î `a Ë%»’¡Moh”ô›ˆÞ¢RÜ”V‘1äÆÝ
+Þdz‚ÖÚF]Å£)1…3{ÑÌ˜bö6·?8=Å:Éd{Z—õ˜„ðêh“ç}ãZõ¹Š)tò¼÷Sè»âaVOs©Ó}o>jWª?´MoÖ÷ïn¦„+ ÞÒx™¦ñîc5¤9DxD·Ê4U—‰<I¾LÕgÕIw%æV±ÈáJ,o{«È4‡¸=)a†CN¼ïsÆM ægu]úàìØt“ë|9TÑÚª·&Kf3;šÒ©\”å6ç}6!{jÄŠ‹•6\¬ØhDVNlg}mé¥GSK%ÏD÷´Äˆc¸îžåŽŽÙÀ”ân§äB,Šªx© íuú9ó ![Æ•Lô-Ú>Ê›ž­dT^ ªÚÊ¶ uLxã[Êi^ö>B•Ã¾•v7¨òd2áZèšW[û=3OH»aéÆäÞzCŒvÃòLUfcò™d€YU.bqm†¥·ÞÎŒÖ‹rt»vguž®b½‘¹ ·•n­Åzsjf½1µr¸°ÞO×áœ„&®â§ZoLoØ=ÄÃ¹´ÞHvËx8oþÈ¦KÖ'³+Ü8Gùþr „dòä¨âS’gI/Q‹‚ôäÌ)4ÖQ–|9ÎVö„ˆ(kó|áN«áŽoS.‚YæóCúÌÞQ×åäBêäôÄõÌSÚ3ílCü¬!\O)€9®VäX2ÄÏ‹“‹â™Ë Ÿ¢@œŸµåÔ1ÎÏàˆæ®ÁlŠgÃ·BöwwòÙDæù¼ä\>2Ïì6
+z[sdÞŠ”æ62ÏÑv=‘yäþf!8Ï{Gö‘y:ßAçŽ–ÌóCÝDÓxÌ³ckŒÌÓùxŽq™çs‘3e‘yúµQ‚óÖ™§£ç­v/T¹¯#ðÎ;‡Yd¢F™‹Ð›«_g×KÌl¦ßÖWB"Øšî.½leX„\>µªF¿Á­–~CîE¯b[Æ°;wä1€©sîÈZ»ö”_GÚ¦óîb¤ô£=c$Pé¥0qtKp·’Ýªv§€*‡0{Y_ãzsµƒÜ¸BïjÊ¥Eõ‚'W	kQâWOuŒ{¹¯®ââŽö£¹w·sGK§äÐ·¸£5þrWmcbHsfã*'ÌpÁa	~3Q»Õ÷WXuí"pÂ‘§Ý¯/Hö~­A²÷k
+’}ùYO,³]C,êe=A²ÐÑZ‚d¡£Õƒd!ŒÎ$k™èÚ<ÌÜ°QLRÁ*.ÄÉ'e»v·[ââ~l‰.Ì`®\{WÊ3kÙ Ëè+Ayfkó‚òYÀIÁ_-(oiÉ?”ç¬{Z01oAy2Ûa­”§U£H\žç <7#Q£ÚS6å-û=D_é}.+ÞCü¾í“:jn|äµ±ºôÞ~ìïÜøJVuèmæBbsFgH¸nuå"C/Ž¥s‘!NN;lq¼²¹òvV´¡Ä«1¥ùRî®ª4ŸÇ9HÌ=S´5×ƒ×[)¨þÞ 1ª…×[½³}&)^ßCáõ&^¿	ìÝä’ðéÚÑ³V‚¦¾SÒát8þ6Xne•>ì.hvwIÑZ4ëÂî¦»[cm‰YC°_¢lo][À…^ìÂîÞ¢–Pq%rŸe°_rS›e»{³»$P}º`?(F®@5…ÙÀ^mâÐ®N®õ”!ìªs[@MôöNî÷&VqhvÁ~ÉŸ´%TºüZµöÛþ¦îÚVPyŸm°_…ÎZB§Ÿ§›–P/›É[ë:…ˆ]ˆamÇ°´°o£>þ$Î»‹$`Þ´±)¸ér£qpÑç­ïm&¾ ¥Ê;½	X;KòïõÙfƒ3·—;C£s¾Ñká¢±@YòL,TæÛš^'ö¹¨Ý™–¨±ñèZ¶¼ž™`ì³J1±|y=c¬ ÔÖó9t‰ªÝ]6•â«­è|íká­TYOßUÄ(ª/êé\heOV
+‡åè’î8&bè‚ayrÚ´“©+úRû†þ¨Ç_\ÉPüd}fCÔ·ë
+ì3“Ä}šŠ1k
+ì3³Yˆ—ìÓMN2U«JáÚûçÚ‘ï=ÍyÕR}‹S*ÆŒ+kì[ÖÜí1°ÏL—Óôzû$ÁAÕ§Òëì3[³YG`Ÿ™víÃ‰4×Øgq‹»îÀ>³¨>éNz}–®½ëì3[a»À*}ú&Q}³Ý:ûÌ¢ú|šª‹k
+ì3[CŸ!qóûÌ¢ú,¨åûÌºòIñžkìs¼,^O`ŸYTßæä	i®û\!mõÀ>…Ü4Q}šcm]}fQ}[ç:ûÌ:Ð^¯)°Ï,ªÏÒjùÀ>3¹ÚRÅ]>°Ï,ªOAšår[¡Å¹T§f•Ì½»W
+ì3‹êsÔ=-1â:þÇò"µÀ>ý”âš %Ï}†19êˆ>Ó Y½Ž˜.„‹Žr‡.JÍZúª9•ñt†ø†'‘Ã]?3²t/r¸®âgæ‘a9œ«ø¹D•þJŠør,‰ªžã‰nHdWp±f¯÷1åÖ¹€ŸÛ JËZ½>“ f'Ty
+×Y3–µ{†·1-duÇ?õ*·•ù¦ô*Ó©Q_2¹÷tg6ó^üÏiõÿ–•×•â¤-íõè¢øŸ+Çðtåâ>(„æXÿÏ]LŸ÷±kèÕŠÿ)]¶õÿ\‡JYÿÓS\z·,QüÏpzZÔÿÓŒ×±øŸÛÜvè¤Ø\•"ÎÖã19sÜ¤1BZ…Yg¯VŽ&Â—&.n	Ué³wotçÝ¿RT®O	+ut6vÜÁËgáâó‡+ö9°n'µE‡K@Pj'5CHSP¶uê£ššf‡Ÿ÷“¬úa£~³d ZÜÁ¤ìÁÕ
+kksµÂé	VuŽoZnA/”þþK–à4ØpG«úâ^ôg ëtÛ‘µ‡–§’kªÃ)Õ\k´ï—4¦_F¿9ßF¹µBoÖò‘Oïé"àõ¶çŠ±ilKÆâ'Z„6G®°©U6­/§ÈÇÝâí0ü¶jò9ëd¹ ,lÅo×ZÜñvõ¸€ ^¸·4B:b†=…PX¹BG+ß“^ÖÆ€tä,á‚vêÈÆÉ[¬JÅ9ŠÂCÅãDÝŒ0èçõìG“º¾%â=—¨ûgm”Jÿ-¹]a0«ïG§ºîDõ•ëþ)º§Ué?1Duÿ|žc£–ªû·(ªJÿ™<í¢SŒ]AR-³ñÖ›§º6î<.£}_~\¸N9ó4$õ9ÄË»~|š(<WÚ¥›h_fÃX_Þ·KÕM´/¿!¸ˆûpˆ¹†hß{Õøµ’GîÈ•.ÙÓl;Z-Ú÷âsÈmç1ú~ÁeÇà	¹D³E¯ˆ×º5õ3ÒùºÛ-Ñ{ •Í±ö`Ke&¸¤"ÂmÛÁàçòÂ
+Ö3Ÿ×"ÍmwèíÛÅö´¶uê‘æÆÐæF÷l‰>’Êu,•9ËcöTªâá&–ª%.H¥ò4£ÐØ^¸»Å¿-'1úëæºs«õõZ³cí.V¼ÆÝ¶§öÚµÞÛÎ)îõ¶\V-«:ô¶®b˜…XÊÝm”«‚-‡’²•Ã6îöÑSÜ­Ù˜´Š–KO»³BÝÆG‰óhâ™"­C}*ŠìlK
+<Í<Bœáü9	„;±S1,à8ÃWÏl)Ë·cz¬é‚óÄ)³-j7ª¾4Ý›ÍXÿÛØ±ŒÌóAlÔ{Ì:$0|À~Z—á³)9|R¡J>ñ‹±„J—?.š–Pw˜ÓVÇ*ÌîÚ•¦Ë75Põ1rÓÍž`™—®ýlŸ5ÞÝ†à¼1$PWüïÐ®_†6BD`HÐåõ}³
+	´	Ü(OãÖP+‘÷;í¾1†î
+ÁTÏ*è2fµ¾kFÈøö(`ääfàä5z£[Z!#ÃÇŸ¤ÅžºC³v>º¨kú6Ž»Lnþ¼•Ží=L}˜CK'Dé¼äT‰TÝÄH Óò\´æLÊÉ'»:;h’%ÝuÒsÑ“w¦Ï¶¬ÛånÙÂ ejL±Ž?Â`¼8nYÉÎáÓ'gíu_U6ær+/H6ÅU·ŒUù”£ÞÙáÒUùw¥ð¸=3l¹ð8gPTeæ¶”×ÌÐÑ^7CkÅ‚í,ÜÀ<Iò»4â¥1Ùù€yÛ7ûÖîïÒpýp’™˜ä÷|+­Å6óC¯œèúè12sn]GD•^îì5nkyÙ”Ö`–~Œu–±§•¼›ÁLíi’¸òý7Ä#*GŒÏ*s’«DW‰W1>%}»)n\Æ­9iZ„ mÜÀ\2—÷>3YMÚì‹«o7Ì†/¯Q“nsKÚïÀ¸¶D]_w^ó%Ì/ßé‰Á#AµIjYçòqvÖòœ«Lú¸D'yÎf…wÒßi‡Tb³´–MŸ±²Ÿ‰×:ÎÎ:ƒ;Q]7¬že€ëjƒ’Iµbdÿ+Ä–šUý1\á¹-õ÷“A,Pv½9©1®†™êÍ©T¹‡išþòHsŒ&ò„4ïùQìæXÚý4ÍêÝ©H[ˆb6JŽJoKôýµRH¢¹äné»lH¢vvñˆ’¨¾lHâ*vh!‰æt°¸(uz
+ItP-]­<†$š¯Òb<â‚Œ·D·(5œž^CÍ¨Ä,Ñ^“vIth­IÛ‡$6nÍçeQ¬PGi®X¡AÛy*+ç³N˜±Îb… ®§P©m±Bí5Ñ,V¸ Iÿ™b….Ív«+t±²Žb…Ò±VûÃÅ
+”[T	–Ûø„ÇEV«e
+ºÎjµZÁC9ìÏ¼Ú¡Î3e•‚‡ö¦jkí±à¡Åä¤j‡+ù@iÚ›|vY­¼<´ ä)n®#Þså0e{®ZðÐ¾Ú¡O.ë¶;°uµCŸ·€²eB-PK<4œbPDŽ¥"	jÛ¹²uz+xhA¥RµCù†}…)Öáë¶à¡s¼çºêžØT;4ôòí«šËiK<ô·¦`|}µCû;7õ¤‚‡+‡’¸+xèªNáêí«útqk+<ôX§pÙ‚‡ú^ŒÕ-.½¼<´“M­ˆ%
+ÚGÇHW«<´÷R Ìf5Ø4©vhu!é¹à¡Æ“Ü¤Ú¡ÍÆÖÅ{¡à¡½œè³óVðÐ&ÞtúÍ¸”:ÝÄ›ÚU;ôÀìÚ‹5jµ‚‡º^|MH`Ù‚‡K\}/SðÐ¢—–ÝMá­¯¿à¦Ts‹»ZÁCû@éBrõ‚‡îÃãV*x¨#3î <Í]ÁÃ¥Euo­ÈíNŽÈ_GGNÕGÝ¨¸®
+Ú÷âSë®¾«Ê›q!0fÙ‚‡ö:„Áf³|ÁC{µÛÄ%>¿TÁC“YkªZª¸^Ú?¾¿\zi:<t™njÕ‚‡Jp¤iµCŸçX\‹‚‡Þcq—*xhÚ‹b¾^Þ£ËPðpÁ®Õ×P«<´Õ×_E¬PðÐÞæ“+”­ZðPÆfÔVuÇÚ*íµ{ÍÚ¬VðÐ^»×lÏÕ
+ê‘f¬v¸¼î¹˜¶ÛA÷´`bÞ
+Ú‰Èik(x¨JŒfÕÌZ
+†m«ávÍ˜‚zGãÃõÖPðÐöÆGBÚ
+Ê3¯v¸ŒdcZðÐþfÂg™ÒÈcÁC«IRíÐ•_§›‚‡öAº>Mr`—™]„…ëJü›õY¡ÖÅuÈÌJÜf)£Eýf³«õþþ:+‡i¥Žª&“Z Ë‚Ê tö±ðH¬‘ø%‹ß$¬Ê½Io¶„‚(]÷O¨ÙÁiŽIß7ÙÝ£"nQ]ÕðÍ%/¶_Â;°vßª½@ìð+`ö~2áƒýëÇðMÿ{L—J_]úŠféòÙUŽ.ûuºr•‰ÒõÚE‹®?>éÆ@èÑÍs.CßÔúwôí´÷AßÑ³}÷v8§ï£wAú)r¢_Ûúííá(­uÍÍèwîa—~?^‰¢X¢ÄéËx_œ3£;qÞJ§»©®gjºíw«êEæãäîõé3°·³ýp¹•Þä·/›•ÓÞ÷öÆF†ºn:Ûµxf§ÑF`¾Š{r\b`™Ä/Þñ² ¼\ùæf›Þºè·Ë±);‘ÖÇ»N§àZDóqµ@¦O
+öï²y|eã#óúýà-$ŠÑ°Í\ã¡‡ð·{B—ógyºüÑ9¥+Ð=§›oÉ6ÄÓ$€G?¥ðaúâ™¦Ê­ DH^Ñ¥»T×?¤©†1ì*ý6Ò•2|1Ê§§¦ ¨z i‘1Û	„.â(µ{aÀÅÀV1M"¡“øí4¾Ú¸€Xàxpˆæ¸n rþPìýlâüÿ“–¶xyÌœÝbö
+Ì~¡ÏSÌ«u²_ˆxÊ%ö<>5'Läóó}ºûÁê?M}oÄð»ÜVf8£é`ŒÂ_}$AÁåÐKÕ©iú±û†¯aék6…¯Qék=Nú ~0+u¾24•¨Ñ¹á¸>ÍÝß¿"~0ËàqâÙ¥Bê3íŽÃšüVáP~PˆªØüÓí±ü F©@ö™Ó€i0Ê³7´nÛšªî©¿iAW
+ÍèJ-†ÙCgÛKõ²b_§_sôàš!Jáfˆ;¾ _.OÔÎ[X|D¿•#Ðd‰àB3à‹iÄXëiÄ™ˆ–/X¤#ø F_oüY êòôê¼ùÍ¡×oÐllBƒ0‚ÒÔc]ÅÍ»æ­~ò)Z¤øƒìçh÷¶|PŠiø'á®•‡+Õ´¯Sqå¹ž‘ùç2]šõ‡ÅAÂeq—¡ÓôU&])Ÿì
+7ÅZW*Þ‰æõÀÈd|Ã†‹‘íy9X­ÕØÐ µ)Ù#W¦Î«DFSíFTZ›Bmj„~¹¥¤Ð~ ™v½BŸž"Sí7ö(ScÑzµyNþÔã¤Åý¾ŽÂ×(>ÑÑ×JIc@}?ÓRGßo*ÍµÑ‰Z?’FôÝå4Þ\«Ü
+=Ÿ±ïç?ÛÒl¾‡IÌb¸|šKïo¡B/YnäéÍ´>\pt“)©ˆ±P6ïÑÔì!¦@íHô2{£™
+sDŸxFþÔeq;7EÇö5šäì+¾0¢Äì®¼:ÚOÝE7ÎËïçÛ|Êr;­iŠ>­„h½^“áÒÝC5wö@ošè²ñžê’ QÏj¯êõ¦,\¤yïµ<‡cå
+2—‡¼„.ž‚gqUæ*b¬Ç7P –Û@ttõ¼5c–]AZ´ÃGÂöÐæÉñÞ“”7Ä?¥&üp¼G¡9ø
+ÆÐ×Ö(™MuÜm€u†%Ö	å\5¬óqƒÎwÙÝ“À+^})#8áÒLjTÿa#Æ¯~$Æ‚4âi¥S]ÂÕ"Ìß]œH Ü"0)qÏâ}€X¬¼«Î"˜ƒx	³9£ÂG©;¨|QxÿÎuu\¶NÓ‰öØ1Îu+2•üO-Ðg=¸ØSf"¡ï„c%¿Aå7ÂNá+Q<¿òƒQ™©FËô¡í¼z|ïjÏ`ø&ú…zÔN4Q÷ÜVö°¢J{2¥iœ7vö2ª÷‘­à{,&¬eŒ}]’Œ‡qè7Ž½öƒm’;ê6ÏTÞøÅV`z…§±û_Ø÷½h…m=ï!±‰p\n/yÆåú7i¼^˜,M´ÖD÷<fwÒh¥S9&RxŽq;ºJõ¯Lg+•¤Ï
+_ÇL5­@åY†é$‡et\w*›@›½A_¿8ÃkL{òuDíÃ#Ðà x,÷¦ÍkhÂT¿RËÑ§m¿†EéÍ$Ó©m•™HýùØÅ›¯é#¿†÷zSÖÅ›ž^C`\/†Ìñ’ºÓq—Û.k/SòiQÓÃÕŽoËU…æø3•}½<ÏäªÉä	úsÏ¿_l^à¯Ùq1[Ü"µÒ}^¸>ù¸avÐS¶YÎl&ŽÊ™­ënáõt¸Àþü)´±¸x‡Î±½ŠLÕ EÅ›A9·µü+†™îXßÚ:É–~^²\¡ØÊÝÞ^JÕË>sò“£rÅÚ°?-Lžk %Ç‹}Yƒ™^HyD4{É-ÔÍi)ÜêånîîÅ}!#~çšó@IýT¯ë%žß•žº=|¢ 0é99[¶Ç¯¡)Õèâô=è7ÅXìà¾Üš½2'û§ß×fs¶˜pf#|4ß	!øÀ 6"§Cœo#­Ü
+ãóI=Ÿ“›Ùú5Â¹ÐÏƒWÞ@ïí,^z™A7½¶U|)V*‡ß¹›"÷£"ÞÖ¥Ù°lþ‘©-…øå)m¶‹Wó»z¦+‰ÂåaNƒm¿ôRþQ4½}îøfvRè—wÄ“»Ý‡Ÿ“qU|,·"U¸“Î5>êñ­âÇÕôoÊiàu·Hw·GE´=³Wž–Ûá°=—ÄùÞçt+öl±Ó8¶Ÿºdr={×S×“›Fü“äâ 2{.'ŠŠ¡«€-Ç†ÅpËS¢³ƒâœ¯ÔOmÖ˜jv|–«&"b¦Åf¾ÄVO2¥t'Rß²oûOõÑQep÷ð‚š<Ó'ÔtÒÃ3ÔY»œ0ÁÊÛÞ™±îi±ÉÍI¡ÿÞ½c©Ý©§m¿<³YeÂX€ZduîA»›°lèBä6ÙÂ{
+[n[{¥¥A/Î(Ítâ`EÓûmç•ÒVáò.X¼Ç­y<Ù½ëêÝÚzÍù éÜe,(Í;º=M±™³)¹-3k|xXi³ýµ:¥Ý³+IqÊ&óIÙàÀz³³–Ï’`ÇÈ€™ç„Ì"lù‚|íåÙ@ô¥Ô+GgèATqÛáXC­"h:ú†íŠÑƒ†öÇÄò¡U˜Çß`CÞ%yÿ¤T{ø&%£C[išžGùÆåÉk¹˜H¼ƒds³ÿ,Öž“§hE‚'Çå˜rWò£®ÕÛ‰àL–1ÎÚ4ô;áäîì°†Öá&PzO6z®dŒÃ§MP‰È±8g¶ÓÚ;ÙéµŠ±ëw±ðq8j»†j+4þ+‰”.„*fïöl.`)Rz^iK„#0«H“N€ZêX%”¶¡Â^¢ðiÓüAƒ–Ã<ñÛµ)ì½·ÁDQÞ‚+Ó<ãûFø®N9Œ´UNv¶£Ýn?›¢ë`E|T¯¾lˆ’=R¼fáAgËS5ƒx9iuOá+ˆüLîÉ5døjcŽ“F ôþ‘–Ìí­.‡óÿ±óFÏ
+Àí™ýºÐi¼Wò\žýº;Î_âßKß'£êÁ¿~ôpÔŽ#ÿÙóMX>=§'Ð.&,Û$fs·Uü#†»ó¸ü¥™õÄûÔµ”vUüØ™l‚|ÝFxè´Ö(Yo;G®wJ÷“ ýš‚^u‹» 9n½ì³%'
+»gÆ²¥yb,Þ6™#Os»Òö›liJó¶Ét’É>ƒëë»ŸÅëé–¿VÈÇh¶tŸ¼ÈE&ôI®suQ.‡§¹È8»[|*Ï^ÒªÉ÷‹“›É~I|m7ö™»tq³;/÷J\ùæ8õ¸²±ÐâŽ`Ý&b¶[«EãÏÜ¸’¶¬ïrÃ%ÕÙ5éU$lBÐKÈšÞ”‰a_›ÑÖþŠ–[·„obO3·WVrÈyã|W³"hbO[«¦ñG-·öúÖžÆ,kOn=ÇÀvÖ€¯—fŠè7+ë2Ì®0+ôR¯‚åN÷á:šÍþ–Üm½ð,~?'.QD¡ólÌ9¾Þ{ÉÝÜ~½Ù[nU>‡?ßØl‰(¶ø¼#‘CŽ'/fÚÃ7Wn}öÊ¹ÿåBÚÁŸPGáò4p,ÜI®Cüe 9ÉóÞyÇíýÀsÈí)C(>E÷vjûRA¥Z‚ß;¯þ‚ÈñgVßþšhm«¿ uþ™ÕÇK¯ÜIÿ±Õ—ýlþðê‡¥0Ÿ?¼úxéÁ3åÏ®>^zìœôGWßÍy³†ÕÇKï“2ô¶¶EÿCe•Hh„„´ n±±–šp|›ÆûÍ!XÕÅÄ,„ª/ºørq¢9¸wã²–ìý°QÈm(×Uwºò_¤¶H¿dè#\Ø:.©Ò)Ì<rêÔñoÌÆÆÑqEVbÇ{ZÀÂo”ËM‹6”¡‡‡ËœÒA?¨‰Â$ˆö.ôŒWK/ûQngÿ™AšY1ÂTÞb$ú
+ÿ†–ñ.F~{¶À›ôe*{¿¶fFJ)l¦ïzU.VHI§qÁ"…½d÷w¼ƒ÷Nî÷xM‰/ek‡‚ÇÏ¯hœñ
+zÀÄŒj^U¼6ó€»ˆOŸwäíz€›rÍí…– ##	iùÐYX®LU}m|Ýâýå“ËºAˆˆ2¢Š}R‹˜à¡8m*xxÑ"aþÜPð GBXËÓz{Ï"×–ñe4x(<ußd<è«Ìa¿e$ìma$È¢zø¸ð£ÝX$­/àA‚*Uè"Ëx°G·•ù¦T.Õø&VÀ;g\¥Ò÷C`L•Äüã³Š„`{ëúE%Ÿ>T²u©µ}x7#(CfI£pÝÇÞ’ƒÐ8Y„Â«ì’ßËj²Úy"ÑU°I¶g(¶êD(ûAÈûÆv"´wÒÒwÀè]KõÑ’–Õ&G`ìöydÏE¶¬ÙD"ƒX Ç6EFÔEºA;Pé
+NOËáN®‚A©þ¸¡ïÃ´KJ¸€qô*{:`˜ rš§=aå>’›ê&›nTÎ
+ºvÔžÚÙqû—r¥É!«ovAivó¢"zJ[7”•,ª†ÒÔJÅVÜ·”†J˜å&B{Ú·>“J²ï³êDXkJs»÷)ÎyÕøáy!L:œñfÝ–Ý ØˆÙ °ï Ý8ô}¸&-Ã 4‡4[qï³Ö"î¶cbì²HÎm‡t¯“)M%#†øþòÍqö©$¾ÅžrÕäEµÀž~ŠÐ¹%
+1¨O< ó€R˜/±ïÕâqx¿¾¿(^©)^Ò^ý¨j:'µƒÕ9Îð|$Å6„=9©1Í=+G:’Âé÷èàÃ!ÄF’a$ÒžŒåÀ:<ü»)[~#ÞŒê4¨»]²FsSÖÐ¥@Pcüù>Mõ/ë¡P²Z8ÄãDˆ>½, :nbªIÖ†¡6§áÛ}Q‰!{wr»ƒkbƒî93'nÍƒôéì³>ŠTƒlhxu@õ#Ì!·Óßê*–`l³	=5R<mû¦…v<©K0RO@­™°PQïqY%gÇÌ^áù	‚3Ÿ´p]î÷íl8ÊÍ—x¥qì°b&ÀV1P!LìHºðÀg6”ìpùôGÂ&ü}˜žVMdäukN`¹cú.¯ð‚êàß¥Á ]|Pd‘gÃÔùÇÉ!û Ë8ò”PÚ]Œê³e¶´?LÈbœ%èüãð€iÿì^ wÂZ…Ò®³á1£Ý}X—;|â±Ã‰E…˜à…7Q“Äu]—¡?˜¯¸ªþËÙÝÄ]¶Uä¹<Õ?@ËÜ8D„—:!Á~X7J¸,­tŸÂÇ¡P H6¹Ö3±„Mê°¡‡˜úÌT˜z‘‰ÔyŠÛáŽ¨¿íc¦š¬g™Ó€µè¾ŽÁa¸rXiì Ñ…Ïc¦s¬AìÇí”ú‹]ºëË¢õM@¶„W ˆ ,}ÿf­:/¬{&R{´ðM³ï÷(KtÔ‡¼N2ª˜<°¼±~=ÍAô*fgøb:œIž½ÿç“˜.gÉâØwPE³¾…\Rœre’¥ë š°#6Ùˆ:WrÞh¹œGGÌ¼‰Õ|¨ G´,.rÅ0.‰×æ±Ó^o³…ÜíÎþèdŸ¾ÛÂÈÀHNÚÝâSù)¨Ãœ\g¨[dl	¦Rx
+çSó'°ùç½7’< Øi°¥šØal"ûØýÉxbq>mÆ1C¢“eX&ÐÀlLƒ ×ËâàŽàüu#ÎD‚å}öuÚŽ¡Ehúã.z©g"Ûhˆ‡Ç)ŒH¶}+’cÅ‰»…×^ÀCX‰\ Æ{ÝÊÚ…W²Åž§Ž0-™p7ÍÀ€Ò„ï‡c¦ò³{†ñE&‚ãÖ 4—Û	5 ™Hu!vX\Íz¶Éíˆ{Çìëlû!œÚ`ß÷»Â² « bl¥::Çß
+l(ÇQß‘àÛ	z.CpušËÝgòL¤=‡õŠ³ÁÏ‡ÝÎd@àzÁeH˜Ho+Ï¾—J§hËTXÄùÚ¼gÅÍ!l>2è„F°25ª¿YÆÌùÝ®	çÛÕ,°=e1’Ld·rÃç”¾…ŒÊ:™ðöq·ÖC9³uøZ¾95Ð§´GoJâKr+œaûTõx8Ê¼ß„¸\drPÌu®Cwˆ=<—îO¸7ìç¬sS8m–ÇOÁëðÁÝCpþÙäpp`>šf'áLâa­@xžáÛ/{Ãð“»_Ú‹ðA¶’l•
+A¸‰Þ
+„k;ß½Oñj›ŽMŸÑ»áÓ>ø§åßÏßË•ASÐ/ÂGé1ì«úúó’«r½ŸÐ|Ú%sÈ‡g<ÊrfsÖtÎ7H`M¸#ˆÜ½=‚³ïÉC´UL7HÒ¢ÈE{®[ö©SÉ—¸H“ªæÙ't˜PuI1Ò!rSTÇyBÍ9„õÜ…|ÞàVè™xSNÏùsŒîýc&C½õhÐ•'˜×žþ„u¡¯ís4M¶‚–àîõRmŸ
+ÃgôFbÚÚxìDïÀ¯óæ¸Ö*g¥w´¾ñ'Ã°ÔáãUÍu.~®UXèÓ÷eåjÿ³#M8ÞcÐ×çÆ¿Ú)pL"~ÝvxÔj|x|p_¹ëË_§Ð›p!c-BnÜš€á[@øüö
+dÑ€O7X&†§ïàŽ úúÉmÑtôž=ƒC<Á×'øNÑ+ðä~$>¨£KðîNÅèÝÍM¡å¹ˆ…[õh$ç¾›8f&c,µrÊýM—ûqO]šõ'+ìr—GÉ•»Ôõ—^0w¯ÜeŽ²â²k“`ÿÔÚ˜é”n¥-É_ ¥KY%'ƒÊ]ž‹gµ@µ?¬"†}ØF,£yS<vŸè÷û)E×^Â3äè
+*9[6ÑÓ¿‚K?8ÖØ÷ƒ³’°žH?Nk$i’LÝÓH»ÚQUg}IM(gíH¨PáÂ,‚1Ðo”tGúšò=1Îb#å–[x*çË*É…°>ñ¶ƒ¬òX“íìl.ø@iû€äUõº1ŸŒ¦ƒGA4ë@Þ7Øz ¿Ò^ìãr°D˜ÛÊÎ4IOÑHòh$¯„­#Lslþ‰«ª"uê‚?>”®Fµêá©sn•ÄB–ø S©×‘ÚÕ
+T`¥CH¾o”ØÐ¼Û¶=™Œ¤3£¢H)-q¹‹RÒÐ¤¸ÀAgêö‘L}÷ZWû÷qEU§ñÈtÀ¶º§Ps>‚z+q;¯‡ T=o=2ÕÇ9•9Š²¡Ø^ƒHUœÍë#|HŸ1á(då£I>cUOùMÜl`	Ñ†HD}üˆYÒÛ„i	i×ÎrpÔƒ¬•pŽi¿}±hgnå@¾@ã¸ªÂ-Óž0qDÆÙ$R&¶à^?‹¤ÓÑ>þŠe]z?ç&ù<dôŠý—+E±Ô‰DÐ2$íá˜v½Q|%ÐŸÏ¶x¼ñ•fCÝh‰ÙªV±#É5RË3•Û`œ>ý¾=DBðn›	 çVš¤Ñî;'E²'ˆfºý.ž3ž0–p¥ôkGñ ­I…¦ÍêŠ1w&iU—¯H-]4— H˜ê·ª˜P%Æ¦Zyš?Ì©
+ÓQ\¥oX Ž.Ó¯%E5¢0HVøM“¬$½“<iôúk·zd > Cðò)Ý‰FžËÝu“2õaëdü/Ïp’©ðÑ<±ƒí8hÑNx0"ÇÖÉ9:Nî¤¥w¸íy-ÚOóÃtÆ@tz…"HºasTt€U(Eò„·u¬b4~^£@’4µ…”±gTì°DýíŸ9[œ?gúz4æi·Û¦T¨`œÛîîÕéæ6ÊídJˆñ&ò–J¡…|ëÜAdü¥ƒ±§Åœ_\SZå­Ä´?ÃqÄØ¾r ŠU	·:DÆ“i…$ç¾„¡œ–3Ò-w;†ÐqŠóZ5FM1EÃÎöÎr`L³­êð/(¤0i™ÞÁ&/SNòˆ'³—H6KÀÛCÇ&›©ˆ»öç¸:uF:`Ô¶jp4³6j\âÁàˆ/Ø:¥ÝFHWÝÛÊ¡e9N(Ôÿ —®¨ÿ0ãZ¡*$4Ôê”ÓØV‚É—­ÁÌfÿZí£Vìö²#“Ð®EÙ÷â×¡ÄµBÛs¶õt’Äor;çŸû@ 	ô`Ó!ýtrÈ…½K˜-¼³—üé²Ä~J öwî†@Ð„Mr¹ýkD‘sv5›â è‹‹µHù¡gÁÇEJËÔðAð‘=FD¶Á1ÕØ.RB.ô#ËíÜçÒ&ek†yÆtá¸.mrìûE©Ä¾ïeáà<§zãØÎS.ñ´õ2ÌïAhèJå–d6.f"ŠÏBOSå–>’ðÜ’a‚çäQxI†)í´Ê;'7‡è$Ê2&SD8/r‘Í¯3$ÿÑ<²	$x 9ã˜Ò`mÄ@Žˆ‘"æ"ô)d·ð>æ
+ÃD/í*$/gS04AQå[\×æÙLDãvÞ«UÄ3Øø—`[µ­"Ó¹>@ÔÞÞ	Õ?Â¦!¹zxç-pÍXÆk´0«…Á(_ƒº$IŸÐÎ&ÙÐÉ^I*@›`‚²\™8uÇ$³ûCÒ ›[–ˆÍH5)ÆvÙR€&¬KºDÑ1Q4õœvÇP( s—y„3ãÌ“üåNøJÇ¼!ä/Âl#ŸC´ëÝ²4Ìl¾ï¤Ò?;GÄ?­4ðû8 â3û”B-HCôE!°`b)|\_L`{">¸hâ˜)J´	ìi+Ëì½ÎÈmÔwKsÀ¤êƒ6€Á,V¦àP@n¼=–¼Ø1VÒø¾,¶dz{ˆñô¿*xÐl±ú™g"w»ø^ˆA²c)×É¤j5¤ˆ¤O/ÄJ¥>ªD{Á#\¦ÑA}ŸËÝ_œK	ýíÕ-•b	¡jŠ	õÌ³–@¡]xRärÅ‡7EyÓœZÖÉhu)E^×³®ý×aëT½:b"“-e¡}øæI²rÙºpo¸,¾ŽXðÛÜxœ˜êÖ”1=Ÿá’ô…Œtò‚¾ œ	Hà Óyz0¨·,4Žpú7`¢jÚ¢5¿ÁÑ—Y;y.Ä°Å(_Æ*ÉÞî#ée¦úvéè›½V!|_+ZE„æXaCÑ/
+#}æB¥Õ¨%Éãý4‹µ
+lBAƒÎ…t‡îaDê)à>c9Äì‡Ü\EºUä98ìE:òa
+‡è`„½:ÕÌF„+¨TÑ#"·SäUá–1DªöWvˆ)%‰æ ç.‹¦2!	%ùÙ—Ù_1-Q&0,à2Îž&i·èAÜQ›¡½‘HÉlT…âë+‡)ôÛ³£B±ÇtÚÄ0Ï–öÎ.a®i¦³ÅTmßF-¯P8]ÝÈ	ÉEþKNcÜ;ªÜÉ•²š$ºô–=üwÂHÓÃwI
+ÝNÛM.šßÀçs‹\¥$·OÉy¾àâQxJø«äXƒN{š¤íÆ–ËÄI”|}
+øNx—Û:8x—òy¿|ÊUÎ4ãÄwkôè]y¶§™C¤°ÝVD´n™®ò ¦}ðyø¡< õ`¢[µžüì"$rë¼ò[X›Àû-ÖQDµ&YðÆº äëû›¦€»Jn×äªíîm¥ó«0iÕž0`ºŠ*âÐ±f¢ßHÄ°3pëº¢±Ã>Ó©6ðW©SÄ¡qu’²ÿ±V
+ s7ðj7ZW#š4·K‘LèM¾„·ºp×á–yË7â7Ô*]šôGë5iÅ*yt¿È¥^»A"ýkü—ŸYµ°ƒJd`±ü–§~¯¡$©Jâà=¡s¶øTcÈ(v	éÓà–•>ÍŸß7,…RO>±À”÷	Òb@àøÃž ÒŠ®¤ÎßC
+Í=ik5¼ïw¿”qåàjkfƒXlAÕ’òƒØ'’¡:ulý'ÛÓÔÄ¿£üÙÖ—ŠÌÓd¨¯Ùñ;ìmœÔ=A,6!}*ò}ÜŽ í•“šÞsÆ5
+7¯åâ`£“»¾yÙ-µ£'÷ a c¡$¯–Ù$ID9"Ô”[	C	µCfcãõ§øÃD°æZ`–¦%®u_â	ŸøVŒÈ¸È€0ýGÒên'kÜ¾‡ñ®H˜Q\ñ	û:B‰©‰n+g!©ÞY¢L™üNÔh¹¶T®Dðlð3$h@.ÿÝ³rÉ€,žHqèî34h5ÀÎ¢RÙÏCªxz0¦QãrL[Å%ó= e€—!0v&'ÊÏO‹I3¬œ„a?žÃŠ¤dwÈrN#ZâÚ•:%W0¸ ØN¦2JV¹ôBì,*ÑRîÿùþJÓ™”?Í2)?u=bCìöGþˆï/¤S¹ÃÜŽºã²(7Â?³â¸3
+£™?ë§rÍB­–N…Î¸+ø#’ñ)¥°Ä¨D(‹yþõ—-˜óÅLå»ºy}È?èÇ#cj¯W=„Ô^àø ÷õ$>Òë÷ ‰Wêc4áÆ¸ˆÒç,ª´Ž‘Z/	âÎô”>DßËãÔ=Gw—yØGùè°‹L.NOÎ2Ó£tõà>V?ÅïJâËýÊ‡¹ÃŽ$ó7„[$½‚zt×	
+I%Õ¨6wÚ‘È^Kš$–™îS»Ù1/ÝçîN¨Ù^1œ‰·)œoýv~zòq{s!¹µ%ÕüöG?[Ã:›—Â†ôÃë—1Tƒø(ÿ!C0ÒþŒ¡
+’ðgdUÀ ªÍ’1TÃ§)²´vÃ¤RÈŸ1,<®×-c¨ˆLÆP|‡ÿ§dUÀ ÛóÉª€­Bë1ìËÕùäJï¶î$ÍPr»0ÇnM8Uáµrý}mŒƒ˜‰æCñq×d5_¢c7ÚŒTÉ@›pÅ­H
+Ôß•êÓåÒ»Ø¿WÞâ—ci"ß¤„¶²ªtýË¥*ÝTÖ/c¤Ø+Y¨¨†X'ÈD!•uBEž#b_WL#úÜ¥Š¯ôOP¿?1,¶ ?z‚”Y}Sé‚6!kÂo¡È“Q—#òLa{"úèsí ÄÎjŠð!±XpM#\vR e!ÈP®Në-Ï1Vô†£˜OÅÜ{ëvšº«B'Ø¸ºS\¬Ní\-Wç¦æ¦sFrzÊlÊKRO	@²Y.)§ŒXí\*)§Œdm–IJà)#OŽZ\&bÙ}FŸZÚÓcRO	|J0¾×¤žÂãd÷'ïI	<e$@`–LJà)#$…]")§Œ>7áë¦I	<e$ðiÂ×—ìÃMFfÉ¤.ÕoÏ¥úp‘Àg¾î””ÀSFŸMøº}RO´é3_w“”ÀSFŸ÷ âÈ˜û¤ž2ø2¸MJà)#ÆÚcRO	|n3,$%X"1Ï2I	<e$° 4I	<!×Hiî“xÊHà3†¯»NJ°lŽI	<e$pMiI	<‚PÚ2I	<e$ÏïI	<e$ÐÒKeFp“‘ Y2)=3d$XêÆI	<e$À¦!ë¤§C½Š„(â]0ä¾ÉªèùH­?®¨Âïá£ËALºU¨œíµÁ¥ŒÁô%—2–ôr¤oËŸ˜ ñ æ[CÆK~£6ÁS"&ÊüÃ³HÆ)½V¦´U‘µ–ÃÈnO©QÒ>ÈÌóÞ™Öv©‡Ûá™ÖvyK	Z['¥}6)¨RC¹bàÐZÃhå6¨F/´†ÑÊg\1þ]kµò|€ñb‚šÅ°[/é:A)W¬öÑþr¯¤ÎV*+©E‘ó1Qâ;QpXO\QØb‰]¡k 
+^Iýv®nq¿œ¦ð;¸VëI(&~£Á:>Ù··vÉVu½µkÛ`Q­]l¨Z>pa@3ô'…XtyU?To7³Ë-¡òú”þÌ5ç[ýÒS÷öÞ£’1û:;‘¶Åã§Ô†­ò8¥Ì}Tº½* +¸§$*Žõi¿‚ÄxÏÈ¦©{ìÕ2†Oœò)N:(í“iOR—­^ý'ÅxýD+Ÿ­u’}SìOœöAñ{K.üþ•gó”4x\»5«ŒfáWU"…¯¯ø:ZrÓ~e”O¬¶éùg~‹›çªü~÷X(†Ó¡r¹t~'_yÎ†	ì‰‰oA°ý]$Òœ­§4Jl3YKõu`2$	ù­¾®+Áþçª¯ãÒëØaèV_Ç¥×OÕ×á6\áÎ³Uuµ÷èçmôSS˜ÍqªZ¢•>û£:ÿ[@<šñ“iô/üMeü›ö³‰ú’€_ëHâÖ~&ä¯#A…öç@”lQ9qVìwfýñˆû³ø·‡óúÜª’oïûƒÿ#Ô ÊÏfb¿=Ÿ	Ó¾¡h"¿Ø®Óëº¢0’Z±~ª6š©áÏì÷D{³Ù$KQÿýwì£ÿ9äcñÂŸ¨‚D5ÔÑ§þý_ü`®t ¦Yü†Eó?”[KãTÚGÖ3IÆ~’.fÑ¼«´nzýii  ‘¸šÉÂ;yEokEÖOˆ¤…ˆ5F¤H·} Grðüyø|Í}Ý.IMn1ùïêÆz]9âŒ?Ç±é¯O´\·£>8/8.ôæñ7Ëk$Íµ“Ü¬?ö#ÿÏh}{ %?Èã‚(ð3¡›ÿ]NÆâLõôŸñCþ‡ûÿ¥~ÏÔ/!Ö?ŸÂ"•£úéX†þo¹ºÂ´ó¿›aq3,÷ñá[ý‰%lœÍd2©Kg2ˆB©TŠeR©x"•¦3	ø%™L$X~LÐ éÄ¸D&gL:•æIx‹£é4Ë%ØLœAí\ýòÀÃ(@ŒbÑÿ~Ã·Sôéýö·Ÿ¡ýçþçWÚßõ¡‡×¾¿ÉX<“È0ñ—¤“‰”ŸÉÄÒq6Î¤“)ô=Îù‡fâ±d&É1™Dš¦SiÆZ04‡FO3h,™¤Ÿáb4“d˜Ms,z×ŸHÄèD2Å&h6ãd˜šyšÉ¤Ré8è/ 8\a	šNÆé4jDÇRL&Ã 4ÆS¨3‚ÅÑ+ôÿkïÜzæºŽ3}oÀÿ¡o8h{r¡É  	‹ #Ó²™$ÅãüûyžÚýñÔŸ$*&8Ì¸)@»«×¡V­]owÏaò"3!+™i—E:Ö€õ|;ae?)öÈ{•YøeL”2XJÎÅEÕË<Ø›ž5µ[¿<‰ÕŒÑº{ZÍJÄ_K*u—»îÇÞ5±–ÅÆ€bçÊT×éYÍ<æîüÉ¹Í6òeXR©­zîzðzuÅ½/YÓ†¢SS­­ÍËà˜YmíˆNáä?ëìL4ëì|pK±ŽK`7Î8ÑQeu3%˜Ws9÷ÌI/~Åž9ñ:Þ…D‰É$±”ù’è‡Å
+¢ß~ŸÒ™×G‰·÷Ÿ~÷ôëg¿~õyë}ýô»ß¥ýí—_}õÃpïû•Û~ðËï¾yúüÛ¯x~üË/áø:Ê’Ó8Jý—¿xíd¿}ñÍïß|2}úR9ð›ß½þÉ[O¢ÿª6þnÙüáÙçß½øæ]L˜0Fþêüí;<æ_'ÿÿÐ€yi—œFðÃs›ÿbîÿöbñÅ7/þãë»Tü	f­º³iß’–Ä,)TYýÈ%C×Ã®r)å`’ÜW_9§hä†Ý$¨¬w·µQ@·42{ß‡\§EÈÐÑÎe¡Êó8j•if„b^ùØuŽÔvjy¶uKô$ˆP†µ]N¼¦ëƒ­‚æUB4jaA¹õ2ê|œC¢ôÆhÜá¢‡(e-ð0é2Ùg ˜WÓdÑóÀ¤¾6ƒnÐÐä'^´1Ûœ®x'Îˆ]B6·Ûšóh½:Lbž2$bîÔ+ŒGb•œ6ÓZrGyo
+ì g]&ø¯7
+nAjZP Ð8§]53Ü	5>Ñ·Dc 	Ze	/ØÐ0 Ö.¬[ŠÂÁ¶ƒä9Ò\ó6 eå”œ¨ž¼e-ˆ/@ÔšÀLïBÂTðŽåVŸì~”(«pZÀ=ÀY„Z‘Bv=+ Î£fW<Óì0l°"Yf¾Mp›CÊ.Ø!M5"y€ïI'Átãæ–„¢qì"â\V(¶ÇÓÁ-ý¾”äO[®¬qD
+´ºfqc@¡ËíÕËòúƒ ˜oø€`Ã<!Àv	`V–‚7¥²•Þ›wvÀYÀ ²Áï®W	Ü,ŠO+÷¸Ô£4ù¿@¨Èø
+d’a°ÑñÏ‚Í™Ã xvÖt)íèð‚Êeôë<oÐ_wá17ÖÊy†>:×¨•R¹•ëÝˆnžDOÞåqõžPnþ€(—‡"×éD¹yßQîåÞQîå~ ©ø)øÕÿùËÿø8Aì.ÝÐcÀºÔ„~eÌ;Àa	bo‰ê^FÓð žÕE`C¡ÞJ¨ëÚ ,ê=¡ã70m«mÐ¡Õ1D1‚ššsNhLÅP#îŠtäáäuÝ=	¢	&ÜÂ±1€Gõ×Ò^	—ú•f­él¬1éz„f(o6Ë²ØžKn¨ÃÆúA­^¶ å4ù‰
+z(j!x©hÒuÙ ¡>Ae«”ÆH®·ìœƒ§^>ÿùÏ@nGBÀK-p8T@ø×g²&€™È¨Ns^RÀð
+½OL‚TbwöƒÕ È• |Ë¤¥ä ™õWÐ2ðh–}CÃtºÙŠ'	èªž"h†¥±(ði½¥( ï,|Åþ û´ØÎÛD€¹™¯.˜ï`ÄÔß²R$ÌKïffi¤‚!‹`\âÝRÄ†²è4ÏŠø&ÎY""†ºSÓ‘Çœ¹"“¹hèðD,€npêñxÓ*˜3]'ÎÓ;Ä…Û§—Sfê29c=£a¨è&uø¸úAÁfi™aW`iì Ëxò†`”@Á¥‚UËÈefÅjq@eP$ÒH„£·DO!ÒjêcŠr+³Þó>ò°€QÒíñnDÜlP.ò6‡%/‰~øúŸ 0â±¶…¡0”	N£#i©­Üjõ ñQÏ²¬ùrñ°C*O‹<ƒY™CCN·qJÁ‚b3N–Éåà¡ØM _ÆCÍxcÛ¼²sp96›ÃãÜÏ27H·{9gOÖOÌ.ž¦wªºØ/›+ƒ•Ëb‹–ÅÐ¢à‹ùæ¹a¬ô¡ ‚ï¡ôÜêTŠ&R'†’³¿B@¶þne‡W‡Çào¤ç?(²zÖSà`î¨ÁrKtsÇÙsáDf<$Ï'ÅÛ<‘0±§6lù¼Â7
+ì$ÌgžŽØØú—ð7Ÿ°/eŸòÓ¯À®RbCE#¯aoN&oS|v>ùgtpE1“$ÂÈâQ>7´×<ªÍ/}NKÉµoÚd5ŽÈ§kõÙ—4€ê1}”òÔÚÛ´›Ïã7´QSŒX\jáR#,\Î(Rz]mL_dÀ-cr8C”cöjKªìáìU`Òa¸ô<Üá¢Îa}H²P°IëÀâC~Kã!¤üSþ“¥¨F°†áN¥¼uÖ;˜–!ùayù°xû®-ÎqŽ=Jyõ¬øÁûx^Þ¿ü^”ú¬ºò!­:XŸÃªÌ»Uw·êîVÝÝªûÈ¬º4*‘Ãûš "˜_àœÓa ÔãÜÐzÔ×ÂMÉ(Z²j]j˜?˜ ÒT!=zo˜ #‚É²
+}Œ€"	PÄ(^ÙcV»Ph¥à
+p£óL¸€NŽ€ê5Ü>o‰žœD€—*” †UÜ×kZÅ\ :³ø`XoÃ„äØ6V0ÞÂ'f\ÊÄÀ}ø2fÙ¹šªGÓûÈž÷)¢	;
+H«£LfiUœÇ÷¡ö…ñÍ‘†*†=@ØÅtµóq9‰„Eˆ´E¥Z8ü‚8ä\†çl4£g7g$gxšíÄ`JÐ¦!È“Ê¤ÈƒqvÚ"Áåt4_a5bžKàÎ\z×Í‹ k–ŒÄ˜êQ/Ø<]ðË/L
+äã\…qY?à~òƒê1 -ÛÉ@m0¤€i@ÚZF‡Û5åÌÉp ð!(ÒæÈ	ë)skÙ±¬+¶f”@s1ÿ|Š<Ê'C°‡p¶X~Ø“ÀH°Ø8C:nzéN`8P!œÒÐÓÿŽi1ÊÖía¦KDy"Sûrî¤(àªÛ‡O’k„Ž­m]ÏyŠ'M9»\÷ˆ¼9SG,ŠÝµ±[œ!–‹öÄŽ"’×ï7ü¾†Q"¶x“ö>aŽ#ûÏ^a§r‹±™†Ð¿Æ0k2tµHÔíƒ cÁh Ö¢‰.†1[$ì<Âv Û#g|êVº}ÈpøXqÙt¨ï¥ùþÑ{
+6Ô	K;'Ð®)5ùKï°ôKï°ô#ƒ¥!"mh¡c}«ó¥U´áÞãŒüþ
+Ýþ©’OEÝú¤;ÙD™*ó(ïHäÈÛ|‹Y!>ÈÍtïBdÀLy$4§ÙÁ{ðÆÐÙoE§á^Ø9ÆåªZ6ƒ=ÐâM-½w1_¥>F¡Nn ¢&Ø]`ö<Ï4“ª^wÕøÙž¬D·Ô'¥GË*P·³µ Ø@Æ¶zßg’k5;ƒ¹Ye?]î°à(ËpPTi2˜éÜ³ÈÖŒ`XÞLFA˜šDÂ–V˜éŸ"•[à,VãgPs²Í<03#\û;xÚž¸
+ÞÁáüLfe;LÈÍ«‰ÀË#ƒ`÷28†Ñ·˜’©Û±éf¦IÂn@g¤™Fj@$c:ºCHW!E¥G˜ sƒ‰Ve‹ú]¡à8å
+ˆm ˜ZŽ\¡c9Ï€@M/‰ì Þ„ê§Æ¹#“¥A× dMÈš›¹…!Ú¾Ho‘¦Uøm˜C¬s ¤;ÂÁ{CQµª9ÍfòŒ‡‰Þ zTÂã½ž‰ôNDÝº›éÞ…¨‰¦–‘™] û_¨7Ÿï	4¶	'R+fäfµ;f¼cÆ;f¼cÆ3~Ì	*¹Å]õ˜ÉÄà–<ëÎ(ÎšZ HˆšêÑZ&clFz—Ú¸‚ÙPø(ìtLuRJ–¯!Zµ*×­×¦¡j{ ©B´¯S¨XÀÅB¬Tk	ßÕ:XV×wÅ°¦¶tzbÖTøk?£üŽ÷ zpËèŒxe¡U€F”w­K“i
+N4³HÕ;L0N˜×ûÊg¤²d*`šûšú¸Ù:MÕÞ¦!°\SÈÙÓ0üLŽ®f:³…x¨™4ÁY¯g;‘Xiú_g«ù„°XÝ5KoÓä‚ên¤´Åü¥™/Þ_~>Ž©?uŽµ ëüª‚^@¹ÝL~œÊ¬ZÀÌ}™ÅR^yòÐ¯+À6{f—·¾v\¸Ûaâ úífA|`!<ìÉŒräj gPå†¢˜í9ëJÏ>±©D}êá5ÃìZ2ÙA‘A7ˆŸår2a[Lf®øœõ¤(Êgªmî[¹¾2¾½Oþ™ã–èÉ»Ü×r8B<Kð¯çt°˜›ËÒ¯)AcúÒƒ+‡£U%pÍÔG r¤ÆoÝ®‘;µÙè†—ø8(~"pËõ[‚}´dÝ’=2Jûœw¤y»&õFº/Ë 
+4¿ÊïÍv>»n§šÔ‡ÆÁÍ“w`Ë{Œ¤÷‰>wŽh$}Þ]–wøy‡Ÿwøù±ÁÏ5’>çÁÈÖ)Uƒ«jŸœ q ‰H{]yCT-„ËV¸Õeo¤´zëh“P„S­) [[‡Î|³j=Âd}]1¦Ã†
+[L­ÿe›7ö-Ñ““ 	Bd iv=ºÎ0±%\ã hœ¼‹È¾‡ì²M‰lQ¶eâs3P
+Hm€[ój‡ÕQ{
+K$$»½5Ë„¡ ±3Xx;sšß¤ˆ}	,íÍ€êmg^s±‚p®=V5w­€ø¸¬uâA“¾Ì¨$‘=@[ËÔš)¢Rä6nÕqKßµ£MafI ˜tz6Y‘Õ˜uœ#Ñx²éÁðzÇž AâšÌi†ãXÏT7=¸žVÅ<RO|ˆtRO
+Àù®V}]˜Çd³ß’È~W>,Ã£öÈ¯6+–_<Es^Ì¨pE£¥G¯„ÕÚƒÐXQgý[Ôwd1òzÛ­m
+ ô*ÖamúPûIa²®yâ\$¿"v-Á‚ú0ÑDÀ=#$ÔsˆÊ²›‹òND7Wî=y ÇÄ`siÎ++wvÇ`wvÇ`ƒÝåàÏK^Sy_üÄvwQù³•ÿyrðýuoy33¥÷4-ê³¶'m“†E51V‡¥>ø¤·}
+°IÀð|’sMâãeuN«ñ«‚Qõœ˜ã{>yýÏc&f`ÛrêÙ-ëbæ‚Íì“€IîPk:óŠ¸õìXagL	þUz¤?¦‰™°m}‚s1½ÁSŒÕÍ«Ä€ÂX3BA´üží6F˜£ê«7;Lœ­)šÅ/	ó·cpdK¬Æ‘¢$qÛ ¢)0§ÆÌ<«nÛ®	,Þ±fŒÁOš¾{€y·+öÆÆ\ikn½¢¬¦YQ•,EìÚ—Z$uš¾asŠÅXð
+	6ÂVCõs¬é<ìÍÂ~¦šÕkÜµL×ÐþXIS½›­YcVÜÇê²ÅŠée(j$¤€¿[ÅLå èX9X>ÝR¿s?v5Áîáû}:/‘7¢×x`æV«Áòa»ºäyÉaùoª¸!„“P˜›ÝÍÆŽófS“R±…°{¾ÎSš=»uZ=hzHnÍ©Ìó¸Îl®Ä¶„¬:¨V¨NŒ>-J¬o(˜2lK11€±qLÞÁf;ªlˆ6V±TøˆÙ(_,êì–LÖÍ¯ ˜ZÚ††	ÞšŒzøkµ¢ÍVƒÁ#,.æ)Çž.DCÔ2Öîa\N€-å³Î;o¯k¾³³¶a0z`VU‹þro—¿ç2±”lIey7k¨mÃu.iº÷bH†¹[¤ÈêÎê<1çcfæã+ú¦.A3ËÝ°	C6;ê&‚_ov{·¥bª=ˆ#WÉŽ0‘—’»y=Q•ÈDÍÐ@ÅD«µö–Ã±ò#O„Ïß:?d/À#.Výõ¸ wôŽ&?® ÀëýˆmÂknOÝÙÅq-›·=\Í¡µ…µ…'Åþ<Í‰L~võä6õì?ÿP€m'Kö£A}šŠa±š¢DÑÍævï ¶‡:{‰Øht£’»!²aß²sˆ0-ïÈ˜ F7`uÞ¸è1Eµ'ti=3'Ryøev$Ûc€Þlif*±®lóÙIPÁÝ¾À3¢æç2ŒœœÿúeËŠóLÛ´Õ‰­g›ÝkÛbC7ëªg°e¿ «âAeú¥#Ûcw3h[Ÿæ¼X6lï°&južÍÚ†lùvKÒ´Ëƒ­2ˆ¨Í<f[¯=B¯Û¥°,[à)?²!=ûWgƒù·l'ˆôöYMxd½ÉÚˆU q…Wà·ýØùXþ˜šÛ¿{ßq1´·çÙäVL~\ÚÞØXlT°¨URöÄ[w´qGw´qGÚøX€F-VGû¥¡É–õ(ÙºÏº¨rÖÑ÷/ÖÞ©…4SÁVñžµèè#;¼F¯µPe¶Ù]–g{ýÔè½ú wO©.F¡º-6}×Šž*”ÙÔýrÆËÑ–¨©<÷Ø±»·ž£UÂµ‘­·úÛ†>Qß‘C«š2£i“*¾œÁ{6†ÂVÖõ’¶lfP¹°£fƒn#ëÌ_©^û'»®kl¼½ý}ä¢xøšãIàžr3DôbæÖ.¶2o±ôoñëaŸÕpzl/áŠê-ÕnçxtË’#Y”l°•mŸvÃV``a;©™ Pr¶/‘ˆödÕz±]{m¢dU·€!¶j˜½ßJÉÛ{ÂûCãŒðjL ßgÜqÆgÜqÆG†3^y5žt[—ƒ/jd-ò8öB{tc9ÑlÎ*GLÎb7ù]Õ;ØÄÎ #"Zý¦0.Ÿè X±¯Ghéùj³ÊmèšÎo«0aŒ­DÇÃ~%E5õÁ(3~`Ó ýÐ¥-Z#6ÇnUu—«}â-ƒ-*ÑÎœ*­Væ¥¿dIša1uŽïý±+ŸÕ¬™IÌ@Ãto6º g:ºrÍdˆf¶œ³C‹m?K¼iÙ£T3ûü&Ûvg³ª]"ag¿©–¶O
+
+.¹ÂœK8ik«öÎk6Vo2ÒvîÉVD½Ð™@¤)b(,´”ƒl±:$^ ÄTí°©åÐ-„Â6¾¹)å¯E€C*ÑŽ”ÁÀýG¶wJîèoQ‡°!ùNß?`>"æèíÜ}WÂ>'‚Vívö56¿´ú£ùv	AŒÃ­eZ§-cËa×Ó¨¥ˆ>1ê6U±¯2…CÓ•u¸‘õ¾n,uè3™5º&ùfˆË†›ÛaYbmðÐó _$ &¬´(ÆBŠQ›‘Øb×MÁ# Å|K(ÐP”´Îí ’ƒ£õ ¥ëd²LfZt”–{m]“í oÙÑÙôTL«”~å¯zdË@mæ],
+Û[ù0[Îàš@nß‰ðž­vÒeÓ²eòÌÌm(v.“08èewýî;£ì°ZÜa´ìtl1’†6#–[|aT]m6`2 ØD™Ëkç+²ìì²Ïl×7Ô¹ælÄ®LÊ¥}s[D|mÌóaMý[6¶™§ýgÜÑÃD€Õn''¤ÕWÝÆL<I˜•£œºã¶²¡@AÆ,]‡ ¾m§Y­Ë?>{—çÆ“÷ôú¢,p¤Úµë»ÃÈ;Œ¼ÃÈFž©Sè†a±o¦Ôídg,ÊÙK9™Zbçj­æ×”
+ÀÍÛZÎ$fiõuÿÕŽO^ÃùöƒGœWš}è³P¢eAS«~QOá¼:B&/Ùû^/ŒY8v¯¯µÏ~EC_J
+äR¥  úªo^òV‡ú§a› ÄD¢8»¡è3Y'D1ã«›Àá[†¢±ˆ/šbD}HœÙˆ£ÚR¯[äÒ|5çÒ=”v•(,b§_Vv‡ËÇ´è¥ÌªtÒWDÒÛL3Ÿª¯£ÚC7!ˆAöÕ-jlQo!³$¨Øœm–o¦›$hÏmzó§ZMòÍ¤Õ–—&s	E×âßfËµ"UO¢&V`éµ‰©„“6ÊÙ’€wì ¸u4é‹´Õû^5qî}zÜŠ¯¿¬ËÊÜ+Ê³}½xŠÀkäY5%ANYU/y™áY“bÎnp²_v9Q^Ðh5XÐÜ|ƒ–ÉN%1Ô~@­öê×^£‘Â¶ÍAÄ+Œ€YÂP	°%Eç0u_ëæEˆ°[ToçI] sÖ…Ÿ(Ï¾:»{v¥ÇZ†½x¬ZÑCvD÷~ß
+fì-˜bavõEb©™hvØ‡…éí+§0p=¸ÕFÿóû]`(*Ü¦yæÉ¹tÆ…Èal¥,ö¨@—ƒöê›bZØÔÏ†Fn+ËÃ ;Þ£³LN[^·óMdÊ\Ó:PP›BàH£×
+°Ü”Ý€Ñ0ÍÆLðèpÄþÚvÌ¬ó½ömb¤“i³ûÒ7Ã%í¸m€ä$V+,¼bY·8É¥q§‡Çµ– ýÇžŸ½Ëãã}áÈù*ªáû6lr»Aíã$ï@ò$ï@òÃÉ»Üåà.~rðöùêÅ/~b	Ï¯ Í¿~öÇïÜrºüêï¾yöì?ÿÍeÿü7ÏþxýàŸÐäÿùòŽÔß~úü»/Ÿ~õåÓoÝ 3ÙŸ:Uþ“¦úo{>úüO¿½_‚?á|veá£×à§aûO÷—OL=}¸þ—ùˆ¶^&½ý?/¿Š©_þå/âwQÈq~ôÚb>ýÍ‹{öÿöï€ìÿõ”Ïþø>o|yûz©üá?ÿµwôÓ¯þ³O0±óôÝ6
+k¾"dæJå/”‹÷¡c²ÚÑakü¯È.~›èÉ#DÖ¯øí9A44»îˆ›î9Ûø<B.¿úìÅóß~ùvþ#ÖãO~Ú<ùXýéß÷ýÛç¿yòô?Ÿ}óÉ'|ð‹|úÅ³_óôË¯ž}óóŸ}ñíÓ?<»<}þüÅwˆÖ×|uùâ›gßÂÛg—o÷âÿø‰?zùƒ_üâoÿáï~þ³ÿÑ¡ìé
+endstreamendobj7 0 obj<</Intent 16 0 R/Name(Layer 1)/Type/OCG/Usage 17 0 R>>endobj16 0 obj[/View/Design]endobj17 0 obj<</CreatorInfo<</Creator(Adobe Illustrator 23.0)/Subtype/Artwork>>>>endobj30 0 obj[29 0 R]endobj47 0 obj<</CreationDate(D:20191029144322-07'00')/Creator(Adobe Illustrator CC 23.0 \(Windows\))/ModDate(D:20191029144906-07'00')/Producer(Adobe PDF library 15.00)/Title(logo-generator)>>endobjxref
+0 48
+0000000004 65535 f
+0000000016 00000 n
+0000000159 00000 n
+0000016343 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000073727 00000 n
+0000000000 00000 f
+0000016394 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000073797 00000 n
+0000073828 00000 n
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000000000 00000 f
+0000020308 00000 n
+0000020532 00000 n
+0000020121 00000 n
+0000073913 00000 n
+0000016831 00000 n
+0000034563 00000 n
+0000034450 00000 n
+0000019283 00000 n
+0000019559 00000 n
+0000019607 00000 n
+0000020192 00000 n
+0000020223 00000 n
+0000033338 00000 n
+0000020880 00000 n
+0000021133 00000 n
+0000033618 00000 n
+0000034637 00000 n
+0000034811 00000 n
+0000036062 00000 n
+0000041835 00000 n
+0000073938 00000 n
+trailer
+<</Size 48/Root 1 0 R/Info 47 0 R/ID[<19DB19D7C4899245B65655BFDE45399A><CCE6BF45B0E5BF4F9A687DE400D4E3A2>]>>
+startxref
+74133
+%%EOF


### PR DESCRIPTION
I like the recent pattern that we've found across the Jupyter projects where we re-purpose parts of the Jupyter logo for sub-communities and spaces. For example:

![image](https://user-images.githubusercontent.com/1839645/67812132-97f69b80-fa5b-11e9-81c5-0bcbec4d3e0b.png)

![image](https://user-images.githubusercontent.com/1839645/67812141-99c05f00-fa5b-11e9-870e-4d9bc56aeb75.png)

I've made logos for these kinds of things a few times now, and have started using a
little template for myself that I can quickly modify and export as a PNG to ensure
that I have the fonts / sizing / colors / spacing correct each time.

I'm adding it through this PR in case it's something that others would find useful too. It's saved in illustrator format (let me know if there's a better format that still retains text information). Here's what you'd see if you opened it in Illustrator:

<img width="518" alt="Illustrator_XupHsUZG0m" src="https://user-images.githubusercontent.com/1839645/67812200-c5434980-fa5b-11e9-9d4e-76cd61cbaf64.png">

Would folks find this useful? If so I am happy to iterate on the details, text, etc
