### PR TITLE
Fix brand guideline link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ README page, rather than individual files.
 
 # Jupyter Brand Guide
 
-The Jupyter Brand Guide can be found [here](https://github.com/jupyter/design/raw/master/brandguide/brand_guide.pdf).
+The Jupyter Brand Guide can be found [here](https://github.com/jupyter/design/blob/main/brandguide/brand_guide.pdf).
 
 # UX Survey
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ README page, rather than individual files.
 
 # Jupyter Brand Guide
 
-The Jupyter Brand Guide can be found [here](https://github.com/jupyter/design/blob/main/brandguide/brand_guide.pdf).
+The Jupyter Brand Guide can be found [here](https://raw.githubusercontent.com/jupyter/design/main/brandguide/brand_guide.pdf).
 
 # UX Survey
 


### PR DESCRIPTION
The previous link was a 404. This links to the pdf on github.